### PR TITLE
feat: add shortcut i for interval flag

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,26 +8,26 @@ ember [flags]
 
 ## Flags
 
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--addr` | string | `http://localhost:2019` | Caddy admin API address (`http://`, `https://`, or `unix//path`) |
-| `--interval` | duration | `1s` | Polling interval |
-| `--timeout` | duration | `0` (none) | Global timeout. Applies to all modes and subcommands. 0 means no timeout. |
+| Flag               | Type | Default | Description |
+|--------------------|------|---------|-------------|
+| `--addr`           | string | `http://localhost:2019` | Caddy admin API address (`http://`, `https://`, or `unix//path`) |
+| `-i`, `--interval` | duration | `1s` | Polling interval |
+| `--timeout`        | duration | `0` (none) | Global timeout. Applies to all modes and subcommands. 0 means no timeout. |
 | `--slow-threshold` | int | `500` | Slow request threshold in milliseconds. Requests above this are highlighted yellow; above 2x are red. |
 | `--frankenphp-pid` | int | `0` (auto) | FrankenPHP PID. Auto-detected if not set. |
-| `--json` | bool | `false` | JSON output mode (streaming JSONL). See [JSON Output](json-output.md). |
-| `--once` | bool | `false` | Output a single snapshot and exit. Requires `--json`. See [JSON Output](json-output.md). |
-| `--expose` | string | _(none)_ | Start Prometheus metrics endpoint on this address (e.g. `:9191`). See [Prometheus Export](prometheus-export.md). |
-| `--daemon` | bool | `false` | Headless mode: no TUI. Requires `--expose`. See [Prometheus Export](prometheus-export.md). |
+| `--json`           | bool | `false` | JSON output mode (streaming JSONL). See [JSON Output](json-output.md). |
+| `--once`           | bool | `false` | Output a single snapshot and exit. Requires `--json`. See [JSON Output](json-output.md). |
+| `--expose`         | string | _(none)_ | Start Prometheus metrics endpoint on this address (e.g. `:9191`). See [Prometheus Export](prometheus-export.md). |
+| `--daemon`         | bool | `false` | Headless mode: no TUI. Requires `--expose`. See [Prometheus Export](prometheus-export.md). |
 | `--metrics-prefix` | string | _(none)_ | Prefix for exported Prometheus metric names. See [Prometheus Export](prometheus-export.md). |
-| `--log-format` | string | `text` | Log format for daemon/json modes (`text` or `json`). JSON format is suitable for log aggregation systems. |
-| `--ca-cert` | string | _(none)_ | Path to CA certificate for TLS verification |
-| `--client-cert` | string | _(none)_ | Path to client certificate for mTLS |
-| `--client-key` | string | _(none)_ | Path to client private key for mTLS |
-| `--insecure` | bool | `false` | Skip TLS certificate verification |
-| `--metrics-auth` | string | _(none)_ | Basic auth for the metrics endpoint (`user:password`). Requires `--expose`. See [Prometheus Export](prometheus-export.md). |
-| `--no-color` | bool | `false` | Disable colors. Also enabled by the `NO_COLOR` env var (see [no-color.org](https://no-color.org/)). |
-| `--version` | | | Print version and exit |
+| `--log-format`     | string | `text` | Log format for daemon/json modes (`text` or `json`). JSON format is suitable for log aggregation systems. |
+| `--ca-cert`        | string | _(none)_ | Path to CA certificate for TLS verification |
+| `--client-cert`    | string | _(none)_ | Path to client certificate for mTLS |
+| `--client-key`     | string | _(none)_ | Path to client private key for mTLS |
+| `--insecure`       | bool | `false` | Skip TLS certificate verification |
+| `--metrics-auth`   | string | _(none)_ | Basic auth for the metrics endpoint (`user:password`). Requires `--expose`. See [Prometheus Export](prometheus-export.md). |
+| `--no-color`       | bool | `false` | Disable colors. Also enabled by the `NO_COLOR` env var (see [no-color.org](https://no-color.org/)). |
+| `--version`        | | | Print version and exit |
 
 ## Environment Variables
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -35,6 +35,12 @@ type config struct {
 	metricsAuth   string
 }
 
+func Run(args []string, version string) error {
+	cmd := newRootCmd(version)
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
 func newRootCmd(version string) *cobra.Command {
 	var cfg config
 
@@ -119,7 +125,7 @@ Keybindings:
 
 	pf := cmd.PersistentFlags()
 	pf.StringVar(&cfg.addr, "addr", "http://localhost:2019", "Caddy admin API address (http://, https://, or unix//path)")
-	pf.DurationVar(&cfg.interval, "interval", 1*time.Second, "Polling interval")
+	pf.DurationVarP(&cfg.interval, "interval", "i", 1*time.Second, "Polling interval")
 	pf.DurationVar(&cfg.timeout, "timeout", 0, "Global timeout (0 = no timeout)")
 	pf.IntVar(&cfg.frankenphpPID, "frankenphp-pid", 0, "FrankenPHP PID (auto-detected if not set)")
 	pf.StringVar(&cfg.caCert, "ca-cert", "", "Path to CA certificate for TLS verification")
@@ -146,12 +152,6 @@ Keybindings:
 	cmd.SetVersionTemplate("ember {{.Version}}\n")
 
 	return cmd
-}
-
-func Run(args []string, version string) error {
-	cmd := newRootCmd(version)
-	cmd.SetArgs(args)
-	return cmd.Execute()
 }
 
 func contextWithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {


### PR DESCRIPTION
👋🏻 hi !

this PR proposes a change to allow `ember -i 100ms`
I tend to run `ember` with interval always with 100ms: I connect, I check, I disconnect

---

Unrelated questions, if I may (avoiding issues) ;) 

- how do you test locally your changes, you have a bare caddyfile you run ember against?
  - if yes, can this be included in the repo to ease contributing (with upgrade to the contributing doc file)
  - it can help after doing the `make build` `./ember` with the default addr

- I see that you add some tabs here and there, and I see the added value of course
  - I run caddy/frankenphp without proxy and cert, so starting v1.1 now the frankenphp tab is in 4th pos
  - do you think those can be configurable in some way? (nitpick obviously, but with plugins systems you may add, this point will arrive I suppose)

---

Any way, thank again for this tool !
I restarted reading/learning some go ^^

cheers !