### PR TITLE
[BC BREAK] Don't mirror some of the already exposed Caddy metrics

### DIFF
--- a/docs/prometheus-export.md
+++ b/docs/prometheus-export.md
@@ -90,15 +90,6 @@ This re-reads `--ca-cert`, `--client-cert`, and `--client-key` files and applies
 | `ember_host_status_rate` | gauge | `host`, `class` (`2xx`, `3xx`, `4xx`, `5xx`) | Request rate by status class |
 | `ember_host_error_rate` | gauge | `host` | Middleware error rate (handler-level errors, distinct from HTTP status codes) |
 
-### Caddy Config Reload
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `caddy_config_last_reload_successful` | gauge | Whether the last config reload succeeded (1) or failed (0) |
-| `caddy_config_last_reload_success_timestamp_seconds` | gauge | Unix timestamp of the last successful config reload |
-
-These metrics are only emitted once Caddy has recorded a successful config reload.
-
 ### Process Metrics
 
 | Metric | Type | Description |

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -54,7 +54,6 @@ func Handler(holder *StateHolder, prefix ...string) http.HandlerFunc {
 		writeErrorMetrics(w, &s, p)
 		writePercentiles(w, &s, p)
 		writeProcessMetrics(w, &s, p)
-		writeReloadMetrics(w, &s, p)
 	}
 }
 
@@ -291,22 +290,6 @@ func writeProcessMetrics(w http.ResponseWriter, s *model.State, prefix string) {
 	fmt.Fprintf(w, "# HELP %s Resident set size of the monitored process\n", rss)
 	fmt.Fprintf(w, "# TYPE %s gauge\n", rss)
 	fmt.Fprintf(w, "%s %d\n", rss, s.Current.Process.RSS)
-}
-
-func writeReloadMetrics(w http.ResponseWriter, s *model.State, prefix string) {
-	if !s.Current.Metrics.HasConfigReloadMetrics {
-		return
-	}
-
-	successful := prefixed(prefix, "caddy_config_last_reload_successful")
-	fmt.Fprintf(w, "# HELP %s Whether the last Caddy config reload succeeded\n", successful)
-	fmt.Fprintf(w, "# TYPE %s gauge\n", successful)
-	fmt.Fprintf(w, "%s %g\n", successful, s.Current.Metrics.ConfigLastReloadSuccessful)
-
-	ts := prefixed(prefix, "caddy_config_last_reload_success_timestamp_seconds")
-	fmt.Fprintf(w, "# HELP %s Timestamp of the last successful Caddy config reload\n", ts)
-	fmt.Fprintf(w, "# TYPE %s gauge\n", ts)
-	fmt.Fprintf(w, "%s %g\n", ts, s.Current.Metrics.ConfigLastReloadSuccessTimestamp)
 }
 
 func HealthHandler(holder *StateHolder, interval time.Duration) http.HandlerFunc {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -202,9 +202,6 @@ func TestHandler_RoundTrip_ValidPrometheus(t *testing.T) {
 	s.Derived.P50 = 12.5
 	s.Derived.P95 = 45.0
 	s.Derived.P99 = 120.3
-	s.Current.Metrics.HasConfigReloadMetrics = true
-	s.Current.Metrics.ConfigLastReloadSuccessful = 1
-	s.Current.Metrics.ConfigLastReloadSuccessTimestamp = 1.7120736e+09
 
 	holder := &StateHolder{}
 	holder.Store(s)
@@ -222,8 +219,6 @@ func TestHandler_RoundTrip_ValidPrometheus(t *testing.T) {
 	assert.Contains(t, families, "frankenphp_request_duration_milliseconds")
 	assert.Contains(t, families, "process_cpu_percent")
 	assert.Contains(t, families, "process_rss_bytes")
-	assert.Contains(t, families, "caddy_config_last_reload_successful")
-	assert.Contains(t, families, "caddy_config_last_reload_success_timestamp_seconds")
 }
 
 func TestHandler_WorkerMetrics_SortedDeterministic(t *testing.T) {
@@ -397,9 +392,6 @@ func TestHandler_WithPrefix_AllMetricsPrefixed(t *testing.T) {
 	s.Derived.P50 = 12.5
 	s.Derived.P95 = 45.0
 	s.Derived.P99 = 120.3
-	s.Current.Metrics.HasConfigReloadMetrics = true
-	s.Current.Metrics.ConfigLastReloadSuccessful = 1
-	s.Current.Metrics.ConfigLastReloadSuccessTimestamp = 1.7120736e+09
 	s.HostDerived = []model.HostDerived{
 		{Host: "test.com", RPS: 100, AvgTime: 25, InFlight: 3,
 			HasPercentiles: true, P50: 10, P90: 30, P95: 50, P99: 120,
@@ -427,54 +419,11 @@ func TestHandler_WithPrefix_AllMetricsPrefixed(t *testing.T) {
 	assert.Contains(t, families, "prod_ember_host_latency_milliseconds")
 	assert.Contains(t, families, "prod_ember_host_inflight")
 	assert.Contains(t, families, "prod_ember_host_status_rate")
-	assert.Contains(t, families, "prod_caddy_config_last_reload_successful")
-	assert.Contains(t, families, "prod_caddy_config_last_reload_success_timestamp_seconds")
 
 	// Original names must NOT be present
 	assert.NotContains(t, families, "frankenphp_threads_total")
 	assert.NotContains(t, families, "ember_host_rps")
 	assert.NotContains(t, families, "process_cpu_percent")
-	assert.NotContains(t, families, "caddy_config_last_reload_successful")
-}
-
-func TestHandler_ReloadMetrics(t *testing.T) {
-	s := stateWithThreads(nil, nil)
-	s.Current.Metrics.HasConfigReloadMetrics = true
-	s.Current.Metrics.ConfigLastReloadSuccessful = 1
-	s.Current.Metrics.ConfigLastReloadSuccessTimestamp = 1.7120736e+09
-
-	holder := &StateHolder{}
-	holder.Store(s)
-
-	body := get(holder).Body.String()
-	assert.Contains(t, body, "# HELP caddy_config_last_reload_successful")
-	assert.Contains(t, body, "# TYPE caddy_config_last_reload_successful gauge")
-	assert.Contains(t, body, "caddy_config_last_reload_successful 1")
-	assert.Contains(t, body, "# HELP caddy_config_last_reload_success_timestamp_seconds")
-	assert.Contains(t, body, "# TYPE caddy_config_last_reload_success_timestamp_seconds gauge")
-	assert.Contains(t, body, "caddy_config_last_reload_success_timestamp_seconds 1.7120736e+09")
-}
-
-func TestHandler_ReloadMetrics_SkippedWhenNoData(t *testing.T) {
-	holder := &StateHolder{}
-	holder.Store(stateWithThreads(nil, nil))
-
-	body := get(holder).Body.String()
-	assert.NotContains(t, body, "caddy_config_last_reload_successful")
-	assert.NotContains(t, body, "caddy_config_last_reload_success_timestamp_seconds")
-}
-
-func TestHandler_ReloadMetrics_FailedState(t *testing.T) {
-	s := stateWithThreads(nil, nil)
-	s.Current.Metrics.HasConfigReloadMetrics = true
-	s.Current.Metrics.ConfigLastReloadSuccessful = 0
-	s.Current.Metrics.ConfigLastReloadSuccessTimestamp = 1.7120736e+09
-
-	holder := &StateHolder{}
-	holder.Store(s)
-
-	body := get(holder).Body.String()
-	assert.Contains(t, body, "caddy_config_last_reload_successful 0")
 }
 
 func TestHandler_ErrorMetrics(t *testing.T) {


### PR DESCRIPTION
`caddy_config_last_reload_successful` and `caddy_config_last_reload_success_timestamp_seconds ` are not exposed anymore, parse them from Caddy metrics instead.