### PR TITLE
Plugin hotkey customization: t-prefix tab-select, digit forwarding, FooterRenderer

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -381,6 +381,7 @@ No regressions detected
 | `Esc` | Close panel / clear search / go back               |
 | `Tab` / `Shift+Tab` | Switch tab                                         |
 | `1` / `2` / `3` | Jump to tab                                        |
+| `t` then `1`..`9` | Tab-select prefix: arm tab-select mode, next digit switches tab (`Esc` cancels) |
 | `Home` / `End` | Jump to first / last item                          |
 | `PgUp` / `PgDn` | Page up / page down                                |
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -348,6 +348,36 @@ type Renderer interface {
 - `StatusCount`: returns a string shown as a badge in the tab bar (e.g., "12 blocked"). Empty string means no badge
 - `HelpBindings`: returns keybindings shown in the `?` help overlay
 
+### Custom footer text (optional)
+
+```go
+type FooterRenderer interface {
+    FooterText(width int) string
+}
+```
+
+Implement `FooterRenderer` on your `Renderer` (or your plugin struct, if it
+also acts as the renderer) to override Ember's footer hint line while your
+tab is active. The width argument is the available footer width in cells:
+useful if you want to elide hints on narrow terminals.
+
+```go
+func (p *yourPlugin) FooterText(width int) string {
+    if p.modal {
+        return "↑/↓ select · enter confirm · esc cancel"
+    }
+    return ""  // use default footer
+}
+```
+
+Returning an empty string falls back to the default footer (Ember's core
+hotkey list, or the tab-select-mode hint when the user is in the tab
+picker). Use this hook when your plugin has modal sub-states with their
+own keybindings: surfacing them in the global footer is more
+discoverable than burning a row of plugin tab real-estate on an inline
+help line. The tab-select-mode hint takes priority over plugin overrides
+so the user can always cancel out.
+
 ### Exporter (optional)
 
 ```go
@@ -525,7 +555,6 @@ The following keys are handled by Ember core and **never** reach your plugin's `
 |--------------------------|-----------------------|
 | `q`, `Ctrl+C`           | Quit                  |
 | `Tab`                    | Switch tab            |
-| `1`-`9`                 | Jump to tab by number |
 | `?`                      | Toggle help overlay   |
 | `g`                      | Toggle graphs         |
 | `p`                      | Pause / resume        |
@@ -541,6 +570,13 @@ The following keys are used by core tabs (Caddy, FrankenPHP) but **forwarded** t
 | `Enter`                  | Open detail panel                |
 | `/`                      | Open filter                      |
 | `r`                      | Restart workers (FrankenPHP)     |
+
+The following keys are offered to your plugin **first** (right-of-refusal): return `true` from `HandleKey` to consume the key, or `false` to let Ember's default behavior run.
+
+| Key                      | Default behavior                   |
+|--------------------------|------------------------------------|
+| `1`-`9`                 | Jump to tab by number              |
+| `t`                      | Arm tab-select mode (then `1`-`9`) |
 
 All other keys reach your plugin's `HandleKey` directly.
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -134,6 +134,10 @@ type App struct {
 	pluginGroups []*pluginGroup
 	ctx          context.Context
 	cancel       context.CancelFunc
+
+	// pendingTabSelect is set after the user pressed `t` and indicates that
+	// the next digit (1..9) selects a tab. Esc or any non-digit cancels.
+	pendingTabSelect bool
 }
 
 const tabPluginBase tab = 100
@@ -282,7 +286,7 @@ func (a *App) View() string {
 		}
 	}
 	tabBar := renderTabBar(a.tabs, a.activeTab, listWidth, counts, a.pluginTabs)
-	help := renderHelp(a.sortBy, a.hostSortBy, a.certSortBy, a.upstreamSortBy, a.routeSortBy, a.paused, listWidth, a.activeTab, a.logFrozen, a.isRoutesView())
+	help := renderHelp(a.sortBy, a.hostSortBy, a.certSortBy, a.upstreamSortBy, a.routeSortBy, a.paused, listWidth, a.activeTab, a.logFrozen, a.isRoutesView(), a.pendingTabSelect, a.activePluginTab())
 
 	var threads []fetcher.ThreadDebugState
 	var hosts []model.HostDerived

--- a/internal/ui/app_keys.go
+++ b/internal/ui/app_keys.go
@@ -20,6 +20,12 @@ func (a *App) handleTabSwitch(key string) (tea.Cmd, bool) {
 			a.switchTab(a.tabs[idx-1])
 		}
 		return a.switchTabCmd(), true
+	case "t":
+		// vim-style tab-select prefix on non-plugin tabs. The plugin-tab
+		// path lives in handleListKey's switch where the plugin gets a
+		// right-of-refusal first.
+		a.pendingTabSelect = true
+		return nil, true
 	}
 	return nil, false
 }
@@ -93,6 +99,25 @@ func (a *App) handleHelpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (a *App) handleListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Tab-select mode: the user pressed `t`, the next digit selects a tab.
+	// Esc cancels, any other key cancels and falls through to normal routing.
+	if a.pendingTabSelect {
+		a.pendingTabSelect = false
+		s := msg.String()
+		if len(s) == 1 && s[0] >= '1' && s[0] <= '9' {
+			idx := int(s[0] - '0')
+			if idx >= 1 && idx <= len(a.tabs) {
+				a.switchTab(a.tabs[idx-1])
+				return a, a.switchTabCmd()
+			}
+			return a, nil
+		}
+		if s == "esc" {
+			return a, nil
+		}
+		// other keys: fall through to normal handling below
+	}
+
 	if a.activeTab == tabConfig {
 		return a.handleConfigListKey(msg)
 	}
@@ -116,11 +141,32 @@ func (a *App) handleListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		a.prevTab()
 		return a, a.switchTabCmd()
 	case "1", "2", "3", "4", "5", "6", "7", "8", "9":
+		// If a plugin tab is active, offer digits to the plugin first
+		// (right-of-refusal, same contract as `t`). When the plugin consumes
+		// the digit, no tab switch happens. When it returns false (the default
+		// for plugins without a digit handler), fall through to the normal
+		// tab-switch behavior so the keybinding stays useful on plugin tabs.
+		if pt := a.activePluginTab(); pt != nil && pt.renderer != nil {
+			if consumed, _ := safePluginHandleKey(pt.renderer, msg); consumed {
+				return a, nil
+			}
+		}
 		idx, _ := strconv.Atoi(msg.String())
 		if idx >= 1 && idx <= len(a.tabs) {
 			a.switchTab(a.tabs[idx-1])
 		}
 		return a, a.switchTabCmd()
+	case "t":
+		// vim-style tab-select prefix. On a plugin tab, give the plugin a
+		// right-of-refusal first (in case it owns `t` as a hotkey). When the
+		// plugin consumes `t`, no mode is entered.
+		if pt := a.activePluginTab(); pt != nil && pt.renderer != nil {
+			if consumed, _ := safePluginHandleKey(pt.renderer, msg); consumed {
+				return a, nil
+			}
+		}
+		a.pendingTabSelect = true
+		return a, nil
 	case "up", "k":
 		if pt := a.activePluginTab(); pt != nil && pt.renderer != nil {
 			safePluginHandleKey(pt.renderer, msg) //nolint:errcheck // consumed status is informational

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -708,6 +708,91 @@ func TestTabSwitch_Key2NoOpWithSingleTab(t *testing.T) {
 	assert.Equal(t, tabCaddy, app.activeTab)
 }
 
+func TestTabSelectMode_SwitchesViaT_Then_Digit(t *testing.T) {
+	app := newAppWithThreads([]fetcher.ThreadDebugState{{Index: 0, IsWaiting: true}})
+	// Synthetic 5-tab setup so digit 5 is in range.
+	app.tabs = []tab{tabCaddy, tabFrankenPHP, tabConfig, tabCertificates, tabLogs}
+	app.tabStates = map[tab]*tabState{
+		tabCaddy: {}, tabFrankenPHP: {}, tabConfig: {}, tabCertificates: {}, tabLogs: {},
+	}
+	app.activeTab = tabCaddy
+
+	app.handleListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	assert.True(t, app.pendingTabSelect, "t should enter tab-select mode")
+	assert.Equal(t, tabCaddy, app.activeTab, "t alone must not switch tabs")
+
+	app.handleListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	assert.False(t, app.pendingTabSelect, "digit should leave tab-select mode")
+	assert.Equal(t, tabLogs, app.activeTab, "digit 5 should switch to 5th tab")
+}
+
+func TestTabSelectMode_EscCancels(t *testing.T) {
+	app := newAppWithThreads([]fetcher.ThreadDebugState{{Index: 0, IsWaiting: true}})
+	app.activeTab = tabCaddy
+
+	app.handleListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	assert.True(t, app.pendingTabSelect)
+
+	app.handleListKey(tea.KeyMsg{Type: tea.KeyEsc})
+	assert.False(t, app.pendingTabSelect, "esc should leave tab-select mode")
+	assert.Equal(t, tabCaddy, app.activeTab, "esc must not switch tabs")
+}
+
+func TestTabSelectMode_OutOfRangeIgnored(t *testing.T) {
+	app := newAppWithThreads([]fetcher.ThreadDebugState{{Index: 0, IsWaiting: true}})
+	// 2 tabs only; digit 9 is out of range.
+	app.activeTab = tabCaddy
+
+	app.handleListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	assert.True(t, app.pendingTabSelect)
+
+	app.handleListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
+	assert.False(t, app.pendingTabSelect, "out-of-range digit should still leave the mode")
+	assert.Equal(t, tabCaddy, app.activeTab, "out-of-range digit must not switch tabs")
+}
+
+func TestTabSelectMode_PluginConsumesT(t *testing.T) {
+	// keyTrackingPlugin returns true from HandleKey: it consumes the `t`.
+	p := &keyTrackingPlugin{stubPlugin: stubPlugin{name: "track"}}
+	cfg := Config{Plugins: []plugin.Plugin{p}}
+	app := NewApp(nil, cfg)
+	app.switchTab(tabPluginBase)
+
+	app.handleListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	assert.Equal(t, "t", p.lastKey, "plugin should receive the t keystroke first")
+	assert.False(t, app.pendingTabSelect, "plugin consumed t, no tab-select mode")
+}
+
+func TestPluginTab_DigitFallsThroughToTabSwitch(t *testing.T) {
+	// stubPlugin.HandleKey returns false: it does NOT consume the digit. The
+	// digit should fall through to the regular tab-switch behavior so plugins
+	// without a digit handler don't break the keybinding.
+	renderer := &stubPlugin{name: "myplugin"}
+	cfg := Config{Plugins: []plugin.Plugin{renderer}}
+	app := NewApp(nil, cfg)
+	// NewApp builds tabs as [tabCaddy, tabLogs, tabConfig, tabCertificates, tabPluginBase].
+	app.switchTab(tabPluginBase)
+	require.Equal(t, tabPluginBase, app.activeTab, "test precondition: plugin tab active")
+
+	app.handleListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	assert.Equal(t, tabCaddy, app.activeTab, "digit 1 should fall through to tab switch when plugin returns false")
+}
+
+func TestPluginTab_DigitConsumedByPlugin(t *testing.T) {
+	// keyTrackingPlugin.HandleKey returns true: it consumes the digit. The
+	// digit must NOT fall through to tab-switch — the plugin owns it.
+	// Regression guard for the early `return a, nil` at app_keys.go:149.
+	p := &keyTrackingPlugin{stubPlugin: stubPlugin{name: "track"}}
+	cfg := Config{Plugins: []plugin.Plugin{p}}
+	app := NewApp(nil, cfg)
+	app.switchTab(tabPluginBase)
+	require.Equal(t, tabPluginBase, app.activeTab, "test precondition: plugin tab active")
+
+	app.handleListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	assert.Equal(t, "1", p.lastKey, "plugin should receive the digit first")
+	assert.Equal(t, tabPluginBase, app.activeTab, "digit 1 must not switch tabs when plugin consumes it")
+}
+
 func TestEnableFrankenPHP_OnFetch(t *testing.T) {
 	app := &App{
 		activeTab:     tabCaddy,

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/alexandre-daubois/ember/internal/model"
+	"github.com/alexandre-daubois/ember/pkg/plugin"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -13,7 +14,25 @@ type binding struct {
 	desc string
 }
 
-func renderHelp(sortBy model.SortField, hostSortBy model.HostSortField, certSortBy model.CertSortField, upstreamSortBy model.UpstreamSortField, routeSortBy model.RouteSortField, paused bool, width int, activeTab tab, logFrozen, routesView bool) string {
+func renderHelp(sortBy model.SortField, hostSortBy model.HostSortField, certSortBy model.CertSortField, upstreamSortBy model.UpstreamSortField, routeSortBy model.RouteSortField, paused bool, width int, activeTab tab, logFrozen, routesView, tabSelect bool, activePlugin *pluginTab) string {
+	if tabSelect {
+		hint := helpKeyStyle.Render("1-9") + helpStyle.Render(" switch tab") +
+			helpStyle.Render("  ·  ") +
+			helpKeyStyle.Render("Esc") + helpStyle.Render(" cancel")
+		return helpStyle.Width(width).Render(" Tab select: " + hint)
+	}
+
+	// Plugin-Override: while a plugin tab is active and the plugin implements
+	// FooterRenderer, give it first refusal on the footer line. Empty return
+	// falls through to the default footer below.
+	if activePlugin != nil && activePlugin.renderer != nil {
+		if fr, ok := activePlugin.renderer.(plugin.FooterRenderer); ok {
+			if hint := safePluginFooterText(fr, width); hint != "" {
+				return helpStyle.Width(width).Render(" " + hint)
+			}
+		}
+	}
+
 	pauseLabel := "pause"
 	if paused {
 		pauseLabel = "resume"
@@ -112,6 +131,7 @@ func renderHelpOverlay(width, height int, hasUpstreams, hasFrankenPHP bool, plug
 		{"Esc", "Close / clear search"},
 		{"Tab/S-Tab", "Switch tab"},
 		{tabHint, "Jump to tab"},
+		{"t", "Enter tab-select mode (then 1-9 to switch)"},
 		{"Home/End", "Jump to first/last"},
 		{"PgUp/PgDn", "Page up/down"},
 	}

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -4,12 +4,28 @@ import (
 	"testing"
 
 	"github.com/alexandre-daubois/ember/internal/model"
+	"github.com/alexandre-daubois/ember/pkg/plugin"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 )
 
+// footerRendererStub satisfies plugin.Renderer + plugin.FooterRenderer with a
+// configurable FooterText return. Used by the plugin-footer-override tests
+// below.
+type footerRendererStub struct {
+	footer string
+}
+
+func (s *footerRendererStub) Update(_ any, _, _ int) plugin.Renderer { return s }
+func (s *footerRendererStub) View(_, _ int) string                   { return "" }
+func (s *footerRendererStub) HandleKey(_ tea.KeyMsg) bool            { return false }
+func (s *footerRendererStub) StatusCount() string                    { return "" }
+func (s *footerRendererStub) HelpBindings() []plugin.HelpBinding     { return nil }
+func (s *footerRendererStub) FooterText(_ int) string                { return s.footer }
+
 func TestRenderHelp_ContainsAllBindings(t *testing.T) {
-	out := renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabFrankenPHP, false, false)
+	out := renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabFrankenPHP, false, false, false, nil)
 	plain := stripANSI(out)
 
 	assert.Contains(t, plain, "navigate")
@@ -21,33 +37,33 @@ func TestRenderHelp_ContainsAllBindings(t *testing.T) {
 }
 
 func TestRenderHelp_ShowsCurrentSortField(t *testing.T) {
-	out := stripANSI(renderHelp(model.SortByMemory, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabFrankenPHP, false, false))
+	out := stripANSI(renderHelp(model.SortByMemory, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabFrankenPHP, false, false, false, nil))
 	assert.Contains(t, out, "sort(memory)")
 }
 
 func TestRenderHelp_LogsTab_RoutesViewShowsSort(t *testing.T) {
-	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteAvg, false, 120, tabLogs, false, true))
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteAvg, false, 120, tabLogs, false, true, false, nil))
 	assert.Contains(t, out, "sort(avg)")
 }
 
 func TestRenderHelp_LogsTab_LogsViewHidesSort(t *testing.T) {
-	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabLogs, false, false))
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabLogs, false, false, false, nil))
 	assert.NotContains(t, out, "sort(")
 }
 
 func TestRenderHelp_PausedShowsResume(t *testing.T) {
-	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, true, 120, tabFrankenPHP, false, false))
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, true, 120, tabFrankenPHP, false, false, false, nil))
 	assert.Contains(t, out, "resume")
 	assert.NotContains(t, out, "pause")
 }
 
 func TestRenderHelp_RespectsWidth(t *testing.T) {
-	out := renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 200, tabFrankenPHP, false, false)
+	out := renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 200, tabFrankenPHP, false, false, false, nil)
 	assert.Equal(t, 200, lipgloss.Width(out))
 }
 
 func TestRenderHelp_CaddyTab(t *testing.T) {
-	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabCaddy, false, false))
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabCaddy, false, false, false, nil))
 	assert.Contains(t, out, "sort(host)")
 	assert.NotContains(t, out, "restart")
 	assert.Contains(t, out, "navigate")
@@ -56,7 +72,7 @@ func TestRenderHelp_CaddyTab(t *testing.T) {
 }
 
 func TestRenderHelp_ConfigTab(t *testing.T) {
-	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabConfig, false, false))
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabConfig, false, false, false, nil))
 	assert.Contains(t, out, "navigate")
 	assert.Contains(t, out, "expand")
 	assert.Contains(t, out, "collapse")
@@ -71,7 +87,7 @@ func TestRenderHelp_ConfigTab(t *testing.T) {
 }
 
 func TestRenderHelp_CertificatesTab(t *testing.T) {
-	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabCertificates, false, false))
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabCertificates, false, false, false, nil))
 	assert.Contains(t, out, "sort(domain)")
 	assert.Contains(t, out, "refresh")
 	assert.Contains(t, out, "filter")
@@ -81,7 +97,7 @@ func TestRenderHelp_CertificatesTab(t *testing.T) {
 }
 
 func TestRenderHelp_LogsTab(t *testing.T) {
-	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabLogs, false, false))
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabLogs, false, false, false, nil))
 	assert.Contains(t, out, "navigate")
 	assert.Contains(t, out, "filter")
 	assert.Contains(t, out, "pause")
@@ -92,12 +108,12 @@ func TestRenderHelp_LogsTab(t *testing.T) {
 }
 
 func TestRenderHelp_LogsTab_PausedShowsResume(t *testing.T) {
-	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabLogs, true, false))
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabLogs, true, false, false, nil))
 	assert.Contains(t, out, "resume")
 }
 
 func TestRenderHelp_SeparatorsPresent(t *testing.T) {
-	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabFrankenPHP, false, false))
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabFrankenPHP, false, false, false, nil))
 	assert.Contains(t, out, "·")
 }
 
@@ -130,4 +146,45 @@ func TestRenderHelpOverlay_WithoutFrankenPHP(t *testing.T) {
 	assert.NotContains(t, out, "1/2/3/4/5")
 	assert.Contains(t, out, "Refresh config/certs")
 	assert.NotContains(t, out, "restart workers")
+}
+
+// Plugin tab is active and the plugin returns a non-empty FooterText hint.
+// Expectation: footer rendered by the plugin replaces the default core
+// footer (no "navigate"/"sort" leftover).
+func TestPluginFooterOverride_NonEmpty(t *testing.T) {
+	pt := &pluginTab{
+		renderer: &footerRendererStub{footer: "custom hint"},
+		tabID:    100,
+	}
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tab(100), false, false, false, pt))
+	assert.Contains(t, out, "custom hint")
+	// Default Caddy/FrankenPHP footer hints must not bleed through.
+	assert.NotContains(t, out, "navigate")
+	assert.NotContains(t, out, "sort(")
+}
+
+// Plugin returns empty string from FooterText: should fall back to the
+// default core footer for the active tab. The default footer carries
+// "navigate"/"quit" entries.
+func TestPluginFooterOverride_EmptyFallback(t *testing.T) {
+	pt := &pluginTab{
+		renderer: &footerRendererStub{footer: ""},
+		tabID:    100,
+	}
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabFrankenPHP, false, false, false, pt))
+	assert.Contains(t, out, "navigate")
+	assert.Contains(t, out, "quit")
+}
+
+// pendingTabSelect is treated as a global-mode hint that wins over any
+// plugin override. Even with a plugin returning a non-empty FooterText, the
+// "Tab select:" hint must take priority.
+func TestPluginFooterOverride_TabSelectWins(t *testing.T) {
+	pt := &pluginTab{
+		renderer: &footerRendererStub{footer: "should not appear"},
+		tabID:    100,
+	}
+	out := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tab(100), false, false, true, pt))
+	assert.Contains(t, out, "Tab select:")
+	assert.NotContains(t, out, "should not appear")
 }

--- a/internal/ui/logs_test.go
+++ b/internal/ui/logs_test.go
@@ -402,12 +402,12 @@ func TestHeader_FrozenShowsPausedPill(t *testing.T) {
 
 func TestHeader_FollowBindingAppearsOnlyWhenFrozen(t *testing.T) {
 	// Live: help shows pause, no follow.
-	help := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabLogs, false, false))
+	help := stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabLogs, false, false, false, nil))
 	assert.Contains(t, help, "pause")
 	assert.NotContains(t, help, "follow")
 
 	// Frozen: help shows resume + follow hint.
-	help = stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabLogs, true, false))
+	help = stripANSI(renderHelp(model.SortByIndex, model.SortByHost, model.SortByCertDomain, model.SortByUpstreamAddress, model.SortByRouteCount, false, 120, tabLogs, true, false, false, nil))
 	assert.Contains(t, help, "resume")
 	assert.Contains(t, help, "follow")
 }

--- a/internal/ui/plugin_bridge.go
+++ b/internal/ui/plugin_bridge.go
@@ -124,6 +124,18 @@ func safePluginStatusCount(r plugin.Renderer) (_ string, err error) {
 	return r.StatusCount(), nil
 }
 
+// safePluginFooterText calls fr.FooterText and recovers from panics. A
+// panicking plugin yields an empty hint, which falls back to the default
+// footer in renderHelp.
+func safePluginFooterText(fr plugin.FooterRenderer, width int) (s string) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			s = ""
+		}
+	}()
+	return fr.FooterText(width)
+}
+
 func safePluginHelpBindings(r plugin.Renderer) (_ []plugin.HelpBinding, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {

--- a/internal/ui/plugin_bridge_test.go
+++ b/internal/ui/plugin_bridge_test.go
@@ -152,6 +152,25 @@ func TestSafePluginHelpBindingsPanic(t *testing.T) {
 	assert.Contains(t, err.Error(), "plugin panic during HelpBindings")
 }
 
+func TestSafePluginFooterText(t *testing.T) {
+	fr := &footerRendererStub{footer: "custom hint"}
+	s := safePluginFooterText(fr, 80)
+	assert.Equal(t, "custom hint", s)
+}
+
+// panicFooterStub satisfies plugin.FooterRenderer with a FooterText that
+// always panics. Used to verify safePluginFooterText recovers and returns
+// the empty-string fallback documented on the function.
+type panicFooterStub struct{}
+
+func (p *panicFooterStub) FooterText(_ int) string { panic("footer boom") }
+
+func TestSafePluginFooterTextPanic(t *testing.T) {
+	fr := &panicFooterStub{}
+	s := safePluginFooterText(fr, 80)
+	assert.Empty(t, s, "panicking FooterText should be recovered to empty string")
+}
+
 func TestDoPluginFetchCmd(t *testing.T) {
 	p := &stubPlugin{name: "ok"}
 	cmd := doPluginFetch(context.Background(), 0, p)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -150,6 +150,17 @@ type HelpBinding struct {
 	Desc string
 }
 
+// FooterRenderer is implemented by plugins that want to override Ember's
+// global footer hint line while the plugin's tab is active. Returning an
+// empty string falls back to the default footer (Ember's core hotkey list
+// or the tab-select-mode hint).
+//
+// Use this to surface plugin-specific keybindings to the operator without
+// burning a row of plugin tab real-estate on an inline help line.
+type FooterRenderer interface {
+	FooterText(width int) string
+}
+
 // Exporter is implemented by plugins that contribute Prometheus metrics
 // to Ember's /metrics endpoint.
 //


### PR DESCRIPTION
Three small additive Plugin API changes — full motivation and design rationale in [this discussion follow-up](https://github.com/alexandre-daubois/ember/discussions/67) (TL;DR: hotkey customization you offered to discuss).

## What

1. **`t`-prefix tab-select mode.** One-shot vim-style; next `1..9` switches, `Esc` cancels. Terminal-agnostic — no `Alt`/`Option` modifier needed.
2. **Digit forwarding to active plugin tab.** Plugin's `Renderer.HandleKey` gets `1..9` first. Returns `true` → consumed; returns `false` → falls through to global tab-switch. Plugin-first right-of-refusal.
3. **`FooterRenderer` optional interface.** New `FooterText(width int) string` method on the renderer chain. Plugin override of the global footer hints. Empty string → fallback. Tab-select-mode hint wins.

```go
type FooterRenderer interface {
    FooterText(width int) string
}
```

## Backward compatibility

No breaking changes, no new mandatory plugin API. Plugins without these opt-ins behave exactly as before. `safePluginFooterText` follows the existing `safePluginHandleKey` / `safePluginStatusCount` panic-recovery pattern.

## Caveat for your call

**Multi-instance + `FooterRenderer`:** Since #62 a plugin can run as multiple instances. Today only the active tab's instance has its `FooterText` rendered. Open to a per-instance contract if you'd prefer — happy to iterate before merge.

## Tests

8 new tests cover all four tab-select paths, all three footer paths, and the digit-fallthrough path. Plus happy+panic pair for `safePluginFooterText` matching the existing `safePlugin*` pattern. `go test -race ./...` clean.

## Diff

9 files, +271 / -16 (single commit).

- `pkg/plugin/plugin.go` — `FooterRenderer` interface
- `internal/ui/plugin_bridge.go` — `safePluginFooterText` wrapper
- `internal/ui/plugin_bridge_test.go` — `safePluginFooterText` happy+panic tests
- `internal/ui/app.go` + `app_keys.go` — `pendingTabSelect` state, `t`-prefix handler, digit forwarding (note: tab-switch routing lives in `app_keys.go` since #62 split it out of `app.go`)
- `internal/ui/help.go` + `help_test.go` — `t` binding entry, footer-override rendering, tests
- `internal/ui/app_test.go` + `logs_test.go` — tab-select-mode tests, signature updates
- `docs/plugins.md` — "Custom footer text" section

Real-world verification: my [ember-crowdsec plugin](https://github.com/rewulff/ember-crowdsec)'s confirm-dialog now accepts free-form duration input (`48h`, `30m`) — previously the digits got swallowed by the tab-switch handler before the plugin saw them.
