### PR TITLE
Add per-route memory columns to the By Route view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Ember are documented here.
 
+## Unreleased
+
+### Added
+
+- **Avg Mem** and **Max Mem** columns in the Logs tab's By Route view: per-route PHP memory usage sampled from busy FrankenPHP threads, sortable like the latency columns. Helps spot memory-hungry routes, detect leaks in worker mode, and size servers from the max footprint (#73).
+
 ## 1.5.0 - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Full documentation is available in the [docs/](docs/index.md) directory:
 - [Caddy Configuration](docs/caddy-configuration.md): Caddyfile requirements
 - [Caddy Dashboard](docs/caddy-dashboard.md): Per-host traffic and latency
 - [FrankenPHP Dashboard](docs/frankenphp-dashboard.md): Thread introspection and workers
-- [Logs](docs/logs.md): Live tailing of access and runtime logs, per-host drill-down, and a By Route view that aggregates traffic by normalized URI pattern
+- [Logs](docs/logs.md): Live tailing of access and runtime logs, per-host drill-down, and a By Route view that aggregates traffic by normalized URI pattern, with per-route latency and FrankenPHP memory stats
 - [CLI Reference](docs/cli-reference.md): Flags, keybindings, shell completions
 - [JSON Output](docs/json-output.md): Streaming JSONL for scripting
 - [Prometheus Export](docs/prometheus-export.md): Metrics, health checks, daemon mode

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -161,11 +161,31 @@ table on that host and drops the prefix.
 | 4xx / 5xx  | Counters per status class; coloured (orange / red) and suffixed with `*` (4xx) or `!` (5xx) so error rows stay scannable when `NO_COLOR` is set |
 | Avg        | Mean latency over the bucket                                             |
 | Max        | Slowest single request                                                   |
+| Avg Mem    | Mean PHP memory usage sampled from busy FrankenPHP threads serving this route (FrankenPHP only, see below) |
+| Max Mem    | Highest sampled PHP memory usage for this route (FrankenPHP only)        |
 
-Press `s` / `S` to cycle the sort field (Count → Pattern → Avg → Max),
-following the visual column order. The active column is marked with `▼`
-in the header, the same glyph the host and upstream tables use, so the
-cue is consistent across the app. `/` filters on method or pattern.
+Press `s` / `S` to cycle the sort field (Count -> Pattern -> Avg -> Max ->
+Avg Mem -> Max Mem), following the visual column order. The active column
+is marked with `▼` in the header, the same glyph the host and upstream
+tables use, so the cue is consistent across the app. `/` filters on
+method or pattern.
+
+### Memory columns
+
+The **Avg Mem** and **Max Mem** columns only appear when a FrankenPHP
+server is detected (and require FrankenPHP 1.12.2 or later, like the
+per-thread metrics of the FrankenPHP tab). They aggregate the same
+per-thread memory usage the FrankenPHP tab shows live, keyed by
+`(method, pattern)`: handy for spotting memory-hungry routes, catching
+leaks in worker mode, or sizing servers and pods from the max footprint.
+
+Two caveats stem from how the data is collected:
+
+- Values are *sampled* each time Ember polls a busy thread, not measured
+  per request: a request that completes between two polls is never
+  sampled (its row shows `—`), and a long request is sampled repeatedly.
+- Thread states do not carry a host, so on the root view two hosts
+  sharing the same `(method, pattern)` show identical memory values.
 
 ### URL normalization
 

--- a/internal/model/routeaggregator.go
+++ b/internal/model/routeaggregator.go
@@ -13,17 +13,35 @@ import (
 // aggregator the route counts would silently top out at the buffer
 // capacity, which is misleading on a busy server.
 //
-// Thread-safety: Track takes the write lock and Snapshot the read lock, so
-// any mix of writers and readers is safe. In production there is a single
-// writer (the log tailer goroutine), which keeps contention negligible: the
-// tailer batches entries so the lock is held for very short bursts.
+// Thread-safety: Track/TrackMemory take the write lock and Snapshot the
+// read lock, so any mix of writers and readers is safe. In production there
+// are two writers (the log tailer goroutine and the TUI poll loop feeding
+// thread memory samples), which keeps contention negligible: the tailer
+// batches entries so the lock is held for very short bursts.
 type RouteAggregator struct {
-	mu      sync.RWMutex
-	buckets map[RouteKey]*RouteStat
+	mu         sync.RWMutex
+	buckets    map[RouteKey]*RouteStat
+	memBuckets map[routeMemKey]*routeMemStat
+}
+
+// routeMemKey deliberately omits the host: memory samples come from
+// FrankenPHP thread states, which do not carry one.
+type routeMemKey struct {
+	Method  string
+	Pattern string
+}
+
+type routeMemStat struct {
+	Samples  int
+	SumBytes float64
+	MaxBytes int64
 }
 
 func NewRouteAggregator() *RouteAggregator {
-	return &RouteAggregator{buckets: make(map[RouteKey]*RouteStat, 64)}
+	return &RouteAggregator{
+		buckets:    make(map[RouteKey]*RouteStat, 64),
+		memBuckets: make(map[routeMemKey]*routeMemStat, 64),
+	}
 }
 
 // Track folds one log entry into the aggregator. Non-access logs and entries
@@ -64,6 +82,33 @@ func (a *RouteAggregator) Track(e fetcher.LogEntry) {
 	}
 }
 
+// TrackMemory folds one memory sample from a busy FrankenPHP thread into the
+// (method, pattern) it is currently serving. Samples are kept separate from
+// the access-log buckets because they arrive on a different path (the poll
+// loop, mid-request) and carry no host; Snapshot merges them into every
+// bucket sharing the (method, pattern). Empty method/URI and non-positive
+// measurements are skipped so callers can pass thread states unfiltered.
+func (a *RouteAggregator) TrackMemory(method, uri string, bytes int64) {
+	if method == "" || uri == "" || bytes <= 0 {
+		return
+	}
+	key := routeMemKey{Method: method, Pattern: NormalizeURI(uri)}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	stat, ok := a.memBuckets[key]
+	if !ok {
+		stat = &routeMemStat{}
+		a.memBuckets[key] = stat
+	}
+	stat.Samples++
+	stat.SumBytes += float64(bytes)
+	if bytes > stat.MaxBytes {
+		stat.MaxBytes = bytes
+	}
+}
+
 // Snapshot returns an unsorted copy of every bucket. The slice is fully
 // detached from the aggregator's internal state, so the caller is free to
 // mutate it (callers always re-sort by their active sort key, so sorting
@@ -77,7 +122,13 @@ func (a *RouteAggregator) Snapshot() []RouteStat {
 	}
 	out := make([]RouteStat, 0, len(a.buckets))
 	for _, s := range a.buckets {
-		out = append(out, *s)
+		cp := *s
+		if ms, ok := a.memBuckets[routeMemKey{Method: cp.Key.Method, Pattern: cp.Key.Pattern}]; ok {
+			cp.MemSamples = ms.Samples
+			cp.MemSumBytes = ms.SumBytes
+			cp.MemMaxBytes = ms.MaxBytes
+		}
+		out = append(out, cp)
 	}
 	return out
 }
@@ -122,4 +173,5 @@ func (a *RouteAggregator) Reset() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.buckets = make(map[RouteKey]*RouteStat, 64)
+	a.memBuckets = make(map[routeMemKey]*routeMemStat, 64)
 }

--- a/internal/model/routeaggregator_test.go
+++ b/internal/model/routeaggregator_test.go
@@ -167,9 +167,78 @@ func TestRouteAggregator_Hosts(t *testing.T) {
 	}
 }
 
+func TestRouteAggregator_TrackMemory(t *testing.T) {
+	agg := NewRouteAggregator()
+	now := time.Now()
+	// Two hosts sharing the same route: memory samples carry no host, so
+	// both buckets must surface the same (method, pattern) aggregates.
+	agg.Track(fetcher.LogEntry{Timestamp: now, Logger: "http.log.access.log0", Host: "a.example", Method: "GET", URI: "/users/1", Status: 200})
+	agg.Track(fetcher.LogEntry{Timestamp: now, Logger: "http.log.access.log0", Host: "b.example", Method: "GET", URI: "/users/2", Status: 200})
+
+	// Samples use raw URIs (as reported by a busy thread) and must land in
+	// the normalized /users/:id bucket.
+	agg.TrackMemory("GET", "/users/7", 40<<20)
+	agg.TrackMemory("GET", "/users/8", 60<<20)
+
+	snap := agg.Snapshot()
+	require.Len(t, snap, 2)
+	for _, s := range snap {
+		assert.Equal(t, "/users/:id", s.Key.Pattern)
+		assert.Equal(t, 2, s.MemSamples)
+		assert.InDelta(t, float64(50<<20), s.AvgMemBytes(), 0.001)
+		assert.Equal(t, int64(60<<20), s.MemMaxBytes)
+	}
+}
+
+func TestRouteAggregator_TrackMemory_SkipsInvalidSamples(t *testing.T) {
+	agg := NewRouteAggregator()
+	agg.Track(makeAccessEntry("GET", "/x", 200, 0, time.Now()))
+
+	agg.TrackMemory("", "/x", 10<<20)   // no method
+	agg.TrackMemory("GET", "", 10<<20)  // no URI
+	agg.TrackMemory("GET", "/x", 0)     // no measurement
+	agg.TrackMemory("GET", "/x", -1024) // nonsensical
+
+	snap := agg.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Zero(t, snap[0].MemSamples)
+	assert.Zero(t, snap[0].MemMaxBytes)
+}
+
+func TestRouteAggregator_TrackMemory_BeforeAccessLog(t *testing.T) {
+	// A thread is sampled mid-request, before Caddy has written the access
+	// log entry (which only lands at completion). The sample must not create
+	// a visible bucket on its own, but must surface once the entry arrives.
+	agg := NewRouteAggregator()
+	agg.TrackMemory("GET", "/x", 30<<20)
+	assert.Nil(t, agg.Snapshot())
+	assert.Zero(t, agg.BucketCount())
+
+	agg.Track(makeAccessEntry("GET", "/x", 200, 0, time.Now()))
+	snap := agg.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, 1, snap[0].MemSamples)
+	assert.Equal(t, int64(30<<20), snap[0].MemMaxBytes)
+}
+
+func TestRouteAggregator_Reset_ClearsMemorySamples(t *testing.T) {
+	agg := NewRouteAggregator()
+	agg.Track(makeAccessEntry("GET", "/x", 200, 0, time.Now()))
+	agg.TrackMemory("GET", "/x", 30<<20)
+	agg.Reset()
+
+	// Same route tracked again after Reset: stale memory aggregates must not
+	// bleed into the fresh session.
+	agg.Track(makeAccessEntry("GET", "/x", 200, 0, time.Now()))
+	snap := agg.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Zero(t, snap[0].MemSamples)
+	assert.Zero(t, snap[0].MemMaxBytes)
+}
+
 func TestRouteAggregator_ConcurrentTrackAndSnapshot(t *testing.T) {
-	// Smoke test for the lock: one writer, several readers, race detector
-	// catches anything wrong (`go test -race`).
+	// Smoke test for the lock: two writers (log tailer + poll loop), several
+	// readers, race detector catches anything wrong (`go test -race`).
 	agg := NewRouteAggregator()
 	now := time.Now()
 	var wg sync.WaitGroup
@@ -180,6 +249,11 @@ func TestRouteAggregator_ConcurrentTrackAndSnapshot(t *testing.T) {
 			agg.Track(makeAccessEntry("GET", "/x", 200, 0, now))
 		}
 		close(stop)
+	})
+	wg.Go(func() {
+		for i := 0; i < 5_000; i++ {
+			agg.TrackMemory("GET", "/x", 10<<20)
+		}
 	})
 	for r := 0; r < 4; r++ {
 		wg.Go(func() {

--- a/internal/model/routestats.go
+++ b/internal/model/routestats.go
@@ -18,6 +18,12 @@ type RouteKey struct {
 // RouteStat aggregates entries that share a RouteKey. Latency is stored in
 // milliseconds (LogEntry.Duration is seconds, multiplied at insertion) so
 // the renderer never has to know the source unit.
+//
+// The Mem* fields hold per-thread PHP memory usage sampled from busy
+// FrankenPHP threads at each poll, not per-request measurements: a request
+// shorter than the polling interval may never be sampled, and a long one is
+// sampled repeatedly. Samples carry no host, so buckets sharing a (method,
+// pattern) surface identical memory aggregates.
 type RouteStat struct {
 	Key           RouteKey
 	Count         int
@@ -27,6 +33,9 @@ type RouteStat struct {
 	Status5xx     int
 	DurationSumMs float64
 	DurationMaxMs float64
+	MemSamples    int
+	MemSumBytes   float64
+	MemMaxBytes   int64
 	LastSeen      time.Time
 }
 
@@ -39,10 +48,21 @@ func (s RouteStat) AvgMs() float64 {
 	return s.DurationSumMs / float64(s.Count)
 }
 
-// RouteSortField cycles in the visual column order (Count → Pattern → Avg →
-// Max), skipping Method and the per-status counters which are not sortable.
-// Last-seen is intentionally absent: the column is no longer surfaced in the
-// UI, so cycling onto an invisible sort key would just confuse users.
+// AvgMemBytes returns 0 (not NaN) when no memory sample has been recorded,
+// mirroring AvgMs.
+func (s RouteStat) AvgMemBytes() float64 {
+	if s.MemSamples == 0 {
+		return 0
+	}
+	return s.MemSumBytes / float64(s.MemSamples)
+}
+
+// RouteSortField cycles in the visual column order (Count -> Pattern -> Avg ->
+// Max -> Avg Mem -> Max Mem), skipping Method and the per-status counters
+// which are not sortable. Last-seen is intentionally absent: the column is
+// no longer surfaced in the UI, so cycling onto an invisible sort key would
+// just confuse users. For the same reason, callers that hide the memory
+// columns (no FrankenPHP) must skip the two mem fields when cycling.
 type RouteSortField int
 
 const (
@@ -50,10 +70,12 @@ const (
 	SortByRoutePattern
 	SortByRouteAvg
 	SortByRouteMax
+	SortByRouteAvgMem
+	SortByRouteMaxMem
 )
 
 var routeSortFieldOrder = []RouteSortField{
-	SortByRouteCount, SortByRoutePattern, SortByRouteAvg, SortByRouteMax,
+	SortByRouteCount, SortByRoutePattern, SortByRouteAvg, SortByRouteMax, SortByRouteAvgMem, SortByRouteMaxMem,
 }
 
 func (s RouteSortField) String() string {
@@ -62,6 +84,10 @@ func (s RouteSortField) String() string {
 		return "avg"
 	case SortByRouteMax:
 		return "max"
+	case SortByRouteAvgMem:
+		return "avg mem"
+	case SortByRouteMaxMem:
+		return "max mem"
 	case SortByRoutePattern:
 		return "pattern"
 	default:
@@ -101,6 +127,14 @@ func SortRoutes(stats []RouteStat, by RouteSortField) {
 		case SortByRouteMax:
 			if a.DurationMaxMs != b.DurationMaxMs {
 				return a.DurationMaxMs > b.DurationMaxMs
+			}
+		case SortByRouteAvgMem:
+			if a.AvgMemBytes() != b.AvgMemBytes() {
+				return a.AvgMemBytes() > b.AvgMemBytes()
+			}
+		case SortByRouteMaxMem:
+			if a.MemMaxBytes != b.MemMaxBytes {
+				return a.MemMaxBytes > b.MemMaxBytes
 			}
 		case SortByRoutePattern:
 			if a.Key.Pattern != b.Key.Pattern {

--- a/internal/model/routestats_test.go
+++ b/internal/model/routestats_test.go
@@ -70,8 +70,9 @@ func TestSortRoutes(t *testing.T) {
 }
 
 func TestRouteSortField_Cycle(t *testing.T) {
-	// Cycle follows the visual column order: Count → Pattern → Avg → Max.
-	order := []RouteSortField{SortByRouteCount, SortByRoutePattern, SortByRouteAvg, SortByRouteMax}
+	// Cycle follows the visual column order: Count -> Pattern -> Avg -> Max ->
+	// Avg Mem -> Max Mem.
+	order := []RouteSortField{SortByRouteCount, SortByRoutePattern, SortByRouteAvg, SortByRouteMax, SortByRouteAvgMem, SortByRouteMaxMem}
 	// Forward and backward cycles must be inverses of each other and wrap
 	// around at both ends, so we walk a full lap in each direction.
 	got := SortByRouteCount
@@ -83,7 +84,7 @@ func TestRouteSortField_Cycle(t *testing.T) {
 		}
 	}
 	got = SortByRouteCount
-	wantBack := []RouteSortField{SortByRouteMax, SortByRouteAvg, SortByRoutePattern, SortByRouteCount}
+	wantBack := []RouteSortField{SortByRouteMaxMem, SortByRouteAvgMem, SortByRouteMax, SortByRouteAvg, SortByRoutePattern, SortByRouteCount}
 	for i, want := range wantBack {
 		got = got.Prev()
 		if got != want {
@@ -114,6 +115,8 @@ func TestRouteSortField_String(t *testing.T) {
 		{SortByRoutePattern, "pattern"},
 		{SortByRouteAvg, "avg"},
 		{SortByRouteMax, "max"},
+		{SortByRouteAvgMem, "avg mem"},
+		{SortByRouteMaxMem, "max mem"},
 		{RouteSortField(999), "count"}, // unknown values fall back to the default
 	}
 	for _, tt := range tests {
@@ -155,6 +158,51 @@ func TestRouteStat_AvgMsZero(t *testing.T) {
 	if s.AvgMs() != 0 {
 		t.Errorf("AvgMs on zero RouteStat = %f", s.AvgMs())
 	}
+}
+
+func TestRouteStat_AvgMemBytesZero(t *testing.T) {
+	// No memory sample yet -> 0, not NaN, so the renderer can branch on the
+	// sample count without a division guard.
+	s := RouteStat{}
+	if s.AvgMemBytes() != 0 {
+		t.Errorf("AvgMemBytes on zero RouteStat = %f", s.AvgMemBytes())
+	}
+}
+
+func TestSortRoutes_ByMem(t *testing.T) {
+	mk := func(pattern string, samples int, sumBytes float64, maxBytes int64) RouteStat {
+		return RouteStat{
+			Key:         RouteKey{Method: "GET", Pattern: pattern},
+			MemSamples:  samples,
+			MemSumBytes: sumBytes,
+			MemMaxBytes: maxBytes,
+		}
+	}
+	a := mk("/a", 2, 100<<20, 60<<20) // avg 50 MB, max 60 MB
+	b := mk("/b", 1, 80<<20, 80<<20)  // avg 80 MB, max 80 MB
+	c := mk("/c", 0, 0, 0)            // never sampled
+
+	t.Run("avg mem", func(t *testing.T) {
+		s := []RouteStat{c, a, b}
+		SortRoutes(s, SortByRouteAvgMem)
+		if s[0].Key != b.Key || s[1].Key != a.Key || s[2].Key != c.Key {
+			t.Errorf("bad order: %+v %+v %+v", s[0].Key, s[1].Key, s[2].Key)
+		}
+	})
+	t.Run("max mem", func(t *testing.T) {
+		s := []RouteStat{c, a, b}
+		SortRoutes(s, SortByRouteMaxMem)
+		if s[0].Key != b.Key || s[1].Key != a.Key || s[2].Key != c.Key {
+			t.Errorf("bad order: %+v %+v %+v", s[0].Key, s[1].Key, s[2].Key)
+		}
+	})
+	t.Run("tie falls through to pattern", func(t *testing.T) {
+		s := []RouteStat{mk("/z", 0, 0, 0), mk("/y", 0, 0, 0)}
+		SortRoutes(s, SortByRouteAvgMem)
+		if s[0].Key.Pattern != "/y" {
+			t.Errorf("expected /y first on tied avg mem, got %q", s[0].Key.Pattern)
+		}
+	})
 }
 
 func TestSortRoutes_PatternTieBreaksOnHostThenMethod(t *testing.T) {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -271,6 +271,43 @@ func TestFetchMsg_UpstreamsAloneCountAsFreshData(t *testing.T) {
 	assert.False(t, app.state.UpstreamDerived[0].Healthy)
 }
 
+func TestFetchMsg_SamplesBusyThreadMemoryIntoRouteAggregator(t *testing.T) {
+	agg := model.NewRouteAggregator()
+	agg.Track(fetcher.LogEntry{
+		Timestamp: time.Now(),
+		Logger:    "http.log.access.log0",
+		Method:    "GET",
+		URI:       "/users/1",
+		Status:    200,
+	})
+
+	app := &App{
+		history:         newHistoryStore(),
+		viewTime:        time.Now(),
+		tabs:            []tab{tabCaddy},
+		activeTab:       tabCaddy,
+		tabStates:       map[tab]*tabState{tabCaddy: {}},
+		downSince:       make(map[string]time.Time),
+		routeAggregator: agg,
+	}
+
+	snap := &fetcher.Snapshot{
+		Threads: fetcher.ThreadsResponse{ThreadDebugStates: []fetcher.ThreadDebugState{
+			{Index: 0, IsBusy: true, CurrentMethod: "GET", CurrentURI: "/users/42", MemoryUsage: 50 << 20},
+			// Idle thread retaining its last request: must not be sampled,
+			// otherwise the same route gains a sample at every poll.
+			{Index: 1, IsBusy: false, CurrentMethod: "GET", CurrentURI: "/users/43", MemoryUsage: 40 << 20},
+		}},
+		Metrics: fetcher.MetricsSnapshot{Workers: map[string]*fetcher.WorkerMetrics{}},
+	}
+	_, _ = app.Update(fetchMsg{snap: snap})
+
+	stats := agg.Snapshot()
+	require.Len(t, stats, 1)
+	assert.Equal(t, 1, stats[0].MemSamples, "only the busy thread must contribute a sample")
+	assert.Equal(t, int64(50<<20), stats[0].MemMaxBytes)
+}
+
 func TestFetchMsg_EmptySnapshotAfterDataMarksStale(t *testing.T) {
 	// Guard the complement of the previous test: when nothing is present
 	// (no threads, no HTTP, no upstreams) we must still enter the stale

--- a/internal/ui/app_update.go
+++ b/internal/ui/app_update.go
@@ -176,6 +176,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			for _, t := range msg.snap.Threads.ThreadDebugStates {
 				a.history.recordMem(t.Index, t.MemoryUsage)
+				// CurrentURI/CurrentMethod only describe an in-flight request
+				// while the thread is busy; idle threads may retain the last
+				// served URI, which would over-sample it at every poll.
+				if t.IsBusy && a.routeAggregator != nil {
+					a.routeAggregator.TrackMemory(t.CurrentMethod, t.CurrentURI, t.MemoryUsage)
+				}
 			}
 			activeThreads := make(map[int]struct{}, len(msg.snap.Threads.ThreadDebugStates))
 			for _, t := range msg.snap.Threads.ThreadDebugStates {

--- a/internal/ui/logs.go
+++ b/internal/ui/logs.go
@@ -85,11 +85,27 @@ func (a *App) renderRoutesView(width, height int, rightStatus string) string {
 	}
 	hint := a.routesEmptyHint(len(visible))
 	showHost := a.logSel.kind == logSelRoutes
-	return renderRoutesTable(visible, localCursor, width, height, a.routeSortBy, showHost, rightStatus, hint)
+	return renderRoutesTable(visible, localCursor, width, height, a.routeSortBy, showHost, a.hasFrankenPHP, rightStatus, hint)
 }
 
 func (a *App) isRoutesView() bool {
 	return a.logSel.kind == logSelRoutes || a.logSel.kind == logSelRoutesHost
+}
+
+// cycleRouteSort walks the sort cycle, skipping the memory fields when the
+// columns are hidden (no FrankenPHP): sorting on an invisible column would
+// reorder rows with no visual cue.
+func (a *App) cycleRouteSort(forward bool) {
+	for {
+		if forward {
+			a.routeSortBy = a.routeSortBy.Next()
+		} else {
+			a.routeSortBy = a.routeSortBy.Prev()
+		}
+		if a.hasFrankenPHP || (a.routeSortBy != model.SortByRouteAvgMem && a.routeSortBy != model.SortByRouteMaxMem) {
+			return
+		}
+	}
 }
 
 // currentRouteStats returns the route table the UI should display. The
@@ -510,12 +526,12 @@ func (a *App) handleLogsListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "s":
 		if a.isRoutesView() {
-			a.routeSortBy = a.routeSortBy.Next()
+			a.cycleRouteSort(true)
 			return a, nil
 		}
 	case "S":
 		if a.isRoutesView() {
-			a.routeSortBy = a.routeSortBy.Prev()
+			a.cycleRouteSort(false)
 			return a, nil
 		}
 	}

--- a/internal/ui/routestable.go
+++ b/internal/ui/routestable.go
@@ -16,17 +16,27 @@ const (
 	colRouteStatus1    = 7
 	colRouteAvg        = 11
 	colRouteMax        = 11
+	colRouteMem        = 10
 	// Pattern is the only flex column; everything else is fixed so the
 	// status counters and latency columns line up vertically across rows.
 	colRouteFixedNonPattern = 1 + colRouteCount + colRouteMethod + 4*colRouteStatus1 + colRouteAvg + colRouteMax
 )
 
-func renderRoutesTable(stats []model.RouteStat, cursor, width, height int, sortBy model.RouteSortField, showHost bool, rightStatus, emptyHint string) string {
+// routeFixedNonPattern is the fixed-column footprint: the memory columns only
+// exist when FrankenPHP is detected, so they only count when shown.
+func routeFixedNonPattern(showMem bool) int {
+	if showMem {
+		return colRouteFixedNonPattern + 2*colRouteMem
+	}
+	return colRouteFixedNonPattern
+}
+
+func renderRoutesTable(stats []model.RouteStat, cursor, width, height int, sortBy model.RouteSortField, showHost, showMem bool, rightStatus, emptyHint string) string {
 	// Pattern absorbs whatever width is left after the fixed columns; on
 	// narrow terminals it gets squeezed (and truncated with an ellipsis by
 	// fitCellLeft) rather than pushing the row past `width` and forcing the
 	// terminal to wrap — keeping the table strictly within its allotment.
-	remaining := width - colRouteFixedNonPattern
+	remaining := width - routeFixedNonPattern(showMem)
 	if remaining < 1 {
 		remaining = 1
 	}
@@ -38,7 +48,7 @@ func renderRoutesTable(stats []model.RouteStat, cursor, width, height int, sortB
 	// wide terminal does not stretch Pattern across half the screen.
 	gap := remaining - patternW
 
-	headerLine := renderLogHeader(buildRoutesHeader(sortBy, patternW, gap), rightStatus, width)
+	headerLine := renderLogHeader(buildRoutesHeader(sortBy, patternW, gap, showMem), rightStatus, width)
 
 	bodyHeight := height - lipgloss.Height(headerLine)
 	if bodyHeight < 1 {
@@ -56,7 +66,7 @@ func renderRoutesTable(stats []model.RouteStat, cursor, width, height int, sortB
 	}
 
 	for i, s := range visible {
-		rows = append(rows, formatRouteRow(s, width, patternW, gap, showHost, i == cursor))
+		rows = append(rows, formatRouteRow(s, width, patternW, gap, showHost, showMem, i == cursor))
 	}
 
 	for len(rows) < bodyHeight {
@@ -70,8 +80,8 @@ func renderRoutesTable(stats []model.RouteStat, cursor, width, height int, sortB
 // buildRoutesHeader pre-pads cells manually because Go's `%-*s` width
 // specifier counts bytes, and lipgloss-styled labels embed ANSI escapes that
 // would silently defeat the padding.
-func buildRoutesHeader(sortBy model.RouteSortField, patternW, gap int) string {
-	return " " +
+func buildRoutesHeader(sortBy model.RouteSortField, patternW, gap int, showMem bool) string {
+	header := " " +
 		padCellRight(routeSortLabel("Count", sortBy, model.SortByRouteCount), colRouteCount) +
 		padCellRight("Method", colRouteMethod) +
 		fitCellLeft(routeSortLabel("Pattern", sortBy, model.SortByRoutePattern), patternW) +
@@ -82,6 +92,11 @@ func buildRoutesHeader(sortBy model.RouteSortField, patternW, gap int) string {
 		padCellLeft(statusLabel("5xx", dangerStyle), colRouteStatus1) +
 		padCellRight(" "+routeSortLabel("Avg", sortBy, model.SortByRouteAvg), colRouteAvg) +
 		padCellRight(" "+routeSortLabel("Max", sortBy, model.SortByRouteMax), colRouteMax)
+	if showMem {
+		header += padCellRight(" "+routeSortLabel("Avg Mem", sortBy, model.SortByRouteAvgMem), colRouteMem) +
+			padCellRight(" "+routeSortLabel("Max Mem", sortBy, model.SortByRouteMaxMem), colRouteMem)
+	}
+	return header
 }
 
 // routeSortLabel uses the same "▼" glyph the host and upstream tables use, so
@@ -116,7 +131,7 @@ func padCellLeft(s string, cells int) string {
 	return strings.Repeat(" ", pad) + s
 }
 
-func formatRouteRow(s model.RouteStat, width, patternW, gap int, showHost, selected bool) string {
+func formatRouteRow(s model.RouteStat, width, patternW, gap int, showHost, showMem, selected bool) string {
 	prefix := " "
 	if selected {
 		prefix = ">"
@@ -158,6 +173,18 @@ func formatRouteRow(s model.RouteStat, width, patternW, gap int, showHost, selec
 		formatRouteStatusCells(s, selected) +
 		padCellRight(" "+avg, colRouteAvg) +
 		padCellRight(" "+maxStr, colRouteMax)
+
+	if showMem {
+		avgMem, maxMem := "—", "—"
+		if s.MemSamples > 0 {
+			avgMem = formatBytes(int64(s.AvgMemBytes()))
+		}
+		if s.MemMaxBytes > 0 {
+			maxMem = formatBytes(s.MemMaxBytes)
+		}
+		row += padCellRight(" "+avgMem, colRouteMem) +
+			padCellRight(" "+maxMem, colRouteMem)
+	}
 
 	if selected {
 		return selectedRowStyle.Width(width).Render(row)

--- a/internal/ui/routestable_test.go
+++ b/internal/ui/routestable_test.go
@@ -16,14 +16,14 @@ func TestBuildRoutesHeader_FitsSqueezedPatternColumn(t *testing.T) {
 	// must truncate the "Pattern" label instead of overflowing its budget and
 	// wrapping onto an extra line (which desyncs the row slicer).
 	for _, patternW := range []int{1, 3, 5} {
-		header := buildRoutesHeader(model.SortByRoutePattern, patternW, 0)
+		header := buildRoutesHeader(model.SortByRoutePattern, patternW, 0, false)
 		assert.LessOrEqualf(t, lipgloss.Width(header), colRouteFixedNonPattern+patternW,
 			"routes header overflows its column budget at patternW=%d", patternW)
 	}
 }
 
 func TestRenderRoutesTable_HeaderColumnOrder(t *testing.T) {
-	out := stripANSI(renderRoutesTable(nil, 0, 160, 4, model.SortByRouteCount, false, "", ""))
+	out := stripANSI(renderRoutesTable(nil, 0, 160, 4, model.SortByRouteCount, false, false, "", ""))
 	header := strings.SplitN(out, "\n", 2)[0]
 	expected := []string{"Count", "Method", "Pattern", "2xx", "3xx", "4xx", "5xx", "Avg", "Max"}
 	prev := -1
@@ -33,6 +33,30 @@ func TestRenderRoutesTable_HeaderColumnOrder(t *testing.T) {
 		assert.Greater(t, idx, prev, "%q should appear after the previous label", label)
 		prev = idx
 	}
+	assert.NotContains(t, header, "Mem", "memory columns must stay hidden without FrankenPHP")
+}
+
+func TestRenderRoutesTable_MemColumns(t *testing.T) {
+	stats := []model.RouteStat{
+		{
+			Key:         model.RouteKey{Method: "GET", Pattern: "/users/:id"},
+			Count:       2,
+			Status2xx:   2,
+			MemSamples:  2,
+			MemSumBytes: float64(100 << 20),
+			MemMaxBytes: 60 << 20,
+		},
+		// Never-sampled route (e.g. requests always finish between polls):
+		// both cells must fall back to a dash instead of "0 B".
+		{Key: model.RouteKey{Method: "GET", Pattern: "/ping"}, Count: 1, Status2xx: 1},
+	}
+	out := stripANSI(renderRoutesTable(stats, -1, 180, 5, model.SortByRouteCount, false, true, "", ""))
+	header := strings.SplitN(out, "\n", 2)[0]
+	assert.Less(t, strings.Index(header, "Max "), strings.Index(header, "Avg Mem"))
+	assert.Less(t, strings.Index(header, "Avg Mem"), strings.Index(header, "Max Mem"))
+	assert.Contains(t, out, "50 MB", "avg mem cell")
+	assert.Contains(t, out, "60 MB", "max mem cell")
+	assert.Contains(t, out, "—", "unsampled route must show the dash fallback")
 }
 
 func TestRenderRoutesTable_HappyPath(t *testing.T) {
@@ -48,7 +72,7 @@ func TestRenderRoutesTable_HappyPath(t *testing.T) {
 			LastSeen:      now.Add(-2 * time.Second),
 		},
 	}
-	out := stripANSI(renderRoutesTable(stats, 0, 120, 5, model.SortByRouteCount, false, "", "no rows"))
+	out := stripANSI(renderRoutesTable(stats, 0, 120, 5, model.SortByRouteCount, false, false, "", "no rows"))
 	assert.Contains(t, out, "Method")
 	assert.Contains(t, out, "Pattern")
 	assert.Contains(t, out, "/users/:id")
@@ -61,7 +85,7 @@ func TestRenderRoutesTable_HappyPath(t *testing.T) {
 func TestRenderRoutesTable_HeaderColumnOrderTightWindow(t *testing.T) {
 	// At 80 columns Pattern should still fit (capped at colRoutePatternMax)
 	// while every other column is preserved end-to-end.
-	out := stripANSI(renderRoutesTable(nil, 0, 80, 4, model.SortByRouteCount, false, "", ""))
+	out := stripANSI(renderRoutesTable(nil, 0, 80, 4, model.SortByRouteCount, false, false, "", ""))
 	header := strings.SplitN(out, "\n", 2)[0]
 	for _, label := range []string{"Count", "Method", "Pattern", "2xx", "3xx", "4xx", "5xx", "Avg", "Max"} {
 		assert.Contains(t, header, label)
@@ -69,7 +93,7 @@ func TestRenderRoutesTable_HeaderColumnOrderTightWindow(t *testing.T) {
 }
 
 func TestRenderRoutesTable_EmptyHint(t *testing.T) {
-	out := stripANSI(renderRoutesTable(nil, 0, 80, 5, model.SortByRouteCount, false, "", "waiting…"))
+	out := stripANSI(renderRoutesTable(nil, 0, 80, 5, model.SortByRouteCount, false, false, "", "waiting…"))
 	assert.Contains(t, out, "waiting…")
 }
 
@@ -79,19 +103,19 @@ func TestRenderRoutesTable_HostPrefixOnRoot(t *testing.T) {
 		{Key: model.RouteKey{Host: "app.localhost", Method: "GET", Pattern: "/users/:id"}, Count: 3, Status2xx: 3},
 	}
 	// showHost=true → the host disambiguates two routes that share the path.
-	root := stripANSI(renderRoutesTable(stats, -1, 160, 6, model.SortByRouteCount, true, "", ""))
+	root := stripANSI(renderRoutesTable(stats, -1, 160, 6, model.SortByRouteCount, true, false, "", ""))
 	assert.Contains(t, root, "api.localhost /users/:id")
 	assert.Contains(t, root, "app.localhost /users/:id")
 
 	// showHost=false (per-host drilldown) → the prefix is dropped.
-	drill := stripANSI(renderRoutesTable(stats[:1], -1, 160, 6, model.SortByRouteCount, false, "", ""))
+	drill := stripANSI(renderRoutesTable(stats[:1], -1, 160, 6, model.SortByRouteCount, false, false, "", ""))
 	assert.NotContains(t, drill, "api.localhost /users")
 	assert.Contains(t, drill, "/users/:id")
 }
 
 func TestRenderRoutesTable_SelectionPrefix(t *testing.T) {
 	stats := []model.RouteStat{{Key: model.RouteKey{Method: "GET", Pattern: "/a"}, Count: 1, Status2xx: 1}}
-	out := renderRoutesTable(stats, 0, 100, 4, model.SortByRouteCount, false, "", "")
+	out := renderRoutesTable(stats, 0, 100, 4, model.SortByRouteCount, false, false, "", "")
 	stripped := stripANSI(out)
 	// First non-header line is the row; selection prefix is ">".
 	lines := strings.Split(stripped, "\n")
@@ -110,7 +134,7 @@ func TestRenderRoutesTable_StatusMarkersNoColor(t *testing.T) {
 			Status5xx: 1,
 		},
 	}
-	out := stripANSI(renderRoutesTable(stats, -1, 120, 4, model.SortByRouteCount, false, "", ""))
+	out := stripANSI(renderRoutesTable(stats, -1, 120, 4, model.SortByRouteCount, false, false, "", ""))
 	assert.Contains(t, out, "2*", "4xx must carry a textual marker for NO_COLOR")
 	assert.Contains(t, out, "1!", "5xx must carry a textual marker for NO_COLOR")
 }
@@ -119,7 +143,7 @@ func TestRenderRoutesTable_PatternTruncation(t *testing.T) {
 	long := "/api/v1/very-long-path-segment-that-should-not-overflow/and/wrap/the/row/" + strings.Repeat("x", 200)
 	stats := []model.RouteStat{{Key: model.RouteKey{Method: "GET", Pattern: long}, Count: 1, Status2xx: 1}}
 	width := 100
-	out := renderRoutesTable(stats, -1, width, 3, model.SortByRouteCount, false, "", "")
+	out := renderRoutesTable(stats, -1, width, 3, model.SortByRouteCount, false, false, "", "")
 	stripped := stripANSI(out)
 	for _, line := range strings.Split(stripped, "\n") {
 		assert.LessOrEqual(t, len(line), width*4, "row should not blow up uncontrollably (allowing for unicode)")
@@ -167,7 +191,7 @@ func TestRenderRoutesTable_FallbacksOnMissingMethodAndPattern(t *testing.T) {
 	// must still render a row with the "—" placeholder rather than leaving
 	// holes in the column grid.
 	stats := []model.RouteStat{{Key: model.RouteKey{}, Count: 1, Status2xx: 1}}
-	out := stripANSI(renderRoutesTable(stats, -1, 120, 4, model.SortByRouteCount, false, "", ""))
+	out := stripANSI(renderRoutesTable(stats, -1, 120, 4, model.SortByRouteCount, false, false, "", ""))
 	assert.Contains(t, out, "—", "empty method and pattern must fall back to a dash")
 }
 
@@ -180,7 +204,7 @@ func TestRenderRoutesTable_OverlongStatsClippedToBodyHeight(t *testing.T) {
 	for i := range stats {
 		stats[i] = model.RouteStat{Key: model.RouteKey{Method: "GET", Pattern: "/r"}, Count: i + 1, Status2xx: 1}
 	}
-	out := renderRoutesTable(stats, -1, 120, 4, model.SortByRouteCount, false, "", "")
+	out := renderRoutesTable(stats, -1, 120, 4, model.SortByRouteCount, false, false, "", "")
 	lines := strings.Split(out, "\n")
 	// header + border (logHeaderHeight=2) + at most bodyHeight=2 rows.
 	assert.LessOrEqual(t, len(lines), 4, "renderer must not exceed `height` lines")
@@ -190,7 +214,7 @@ func TestRenderRoutesTable_TinyHeightStillRendersOneRow(t *testing.T) {
 	// height ≤ header → bodyHeight clamps to 1 so the table never collapses
 	// to nothing; the user always sees at least the top row.
 	stats := []model.RouteStat{{Key: model.RouteKey{Method: "GET", Pattern: "/a"}, Count: 1, Status2xx: 1}}
-	out := stripANSI(renderRoutesTable(stats, -1, 120, 1, model.SortByRouteCount, false, "", ""))
+	out := stripANSI(renderRoutesTable(stats, -1, 120, 1, model.SortByRouteCount, false, false, "", ""))
 	assert.Contains(t, out, "/a")
 }
 
@@ -200,6 +224,6 @@ func TestRenderRoutesTable_VeryNarrowWidthClampsPattern(t *testing.T) {
 	// still overflow the requested width on a sub-72-col terminal — but
 	// the renderer must not panic or truncate other columns.
 	stats := []model.RouteStat{{Key: model.RouteKey{Method: "GET", Pattern: "/a"}, Count: 1, Status2xx: 1}}
-	out := renderRoutesTable(stats, -1, 40, 4, model.SortByRouteCount, false, "", "")
+	out := renderRoutesTable(stats, -1, 40, 4, model.SortByRouteCount, false, false, "", "")
 	assert.NotEmpty(t, stripANSI(out))
 }

--- a/internal/ui/routesview_test.go
+++ b/internal/ui/routesview_test.go
@@ -190,6 +190,49 @@ func TestHandleLogsListKey_SortCyclesInRoutesView(t *testing.T) {
 	assert.Equal(t, model.SortByRouteCount, app.routeSortBy, "S walks back to Count")
 }
 
+func TestCycleRouteSort_SkipsMemFieldsWithoutFrankenPHP(t *testing.T) {
+	// The memory columns only render when FrankenPHP is detected; cycling
+	// onto them anyway would reorder rows on an invisible key.
+	app := newRoutesApp(model.NewRouteAggregator())
+	require.False(t, app.hasFrankenPHP)
+
+	app.routeSortBy = model.SortByRouteMax
+	app.cycleRouteSort(true)
+	assert.Equal(t, model.SortByRouteCount, app.routeSortBy, "forward cycle must skip both mem fields")
+
+	app.cycleRouteSort(false)
+	assert.Equal(t, model.SortByRouteMax, app.routeSortBy, "backward cycle must skip both mem fields")
+}
+
+func TestCycleRouteSort_ReachesMemFieldsWithFrankenPHP(t *testing.T) {
+	app := newRoutesApp(model.NewRouteAggregator())
+	app.hasFrankenPHP = true
+
+	app.routeSortBy = model.SortByRouteMax
+	app.cycleRouteSort(true)
+	assert.Equal(t, model.SortByRouteAvgMem, app.routeSortBy)
+	app.cycleRouteSort(true)
+	assert.Equal(t, model.SortByRouteMaxMem, app.routeSortBy)
+	app.cycleRouteSort(true)
+	assert.Equal(t, model.SortByRouteCount, app.routeSortBy, "cycle wraps after the last column")
+}
+
+func TestRenderRoutesView_MemColumnsFollowFrankenPHPDetection(t *testing.T) {
+	agg := model.NewRouteAggregator()
+	trackAccess(agg, "api.localhost", "GET", "/users/1", 200)
+	agg.TrackMemory("GET", "/users/1", 50<<20)
+	app := newRoutesApp(agg)
+
+	without := stripANSI(app.renderRoutesView(200, 8, ""))
+	assert.NotContains(t, without, "Avg Mem", "no FrankenPHP -> no memory columns")
+
+	app.hasFrankenPHP = true
+	with := stripANSI(app.renderRoutesView(200, 8, ""))
+	assert.Contains(t, with, "Avg Mem")
+	assert.Contains(t, with, "Max Mem")
+	assert.Contains(t, with, "50 MB")
+}
+
 func TestRenderRoutesTable_RespectsWidthAt80Columns(t *testing.T) {
 	// Regression: the previous implementation forced remaining≥12, which
 	// pushed the row past `width` on terminals just under 83 cols. The fix
@@ -202,7 +245,7 @@ func TestRenderRoutesTable_RespectsWidthAt80Columns(t *testing.T) {
 		DurationMaxMs: 30,
 	}}
 	for _, width := range []int{72, 80, 100, 160} {
-		out := renderRoutesTable(stats, 0, width, 4, model.SortByRouteCount, false, "", "")
+		out := renderRoutesTable(stats, 0, width, 4, model.SortByRouteCount, false, false, "", "")
 		for _, line := range strings.Split(stripANSI(out), "\n") {
 			assert.LessOrEqualf(t, lipgloss.Width(line), width,
 				"row exceeds requested width=%d: %q", width, line)

--- a/internal/ui/sanitize_render_test.go
+++ b/internal/ui/sanitize_render_test.go
@@ -56,11 +56,11 @@ func TestRenderSinksNeutralizeControlBytes(t *testing.T) {
 		}},
 		{"formatRouteRow method+pattern+host", func() string {
 			s := model.RouteStat{Key: model.RouteKey{Host: evil, Method: evil, Pattern: evil}, Count: 1, Status2xx: 1}
-			return formatRouteRow(s, 120, 40, 0, true, false)
+			return formatRouteRow(s, 120, 40, 0, true, false, false)
 		}},
 		{"formatRouteRow selected", func() string {
 			s := model.RouteStat{Key: model.RouteKey{Host: evil, Method: evil, Pattern: evil}, Count: 1, Status2xx: 1}
-			return formatRouteRow(s, 120, 40, 0, true, true)
+			return formatRouteRow(s, 120, 40, 0, true, false, true)
 		}},
 		{"formatCertRow subject+issuer", func() string {
 			c := fetcher.CertificateInfo{Subject: evil, Issuer: evil, NotAfter: now.Add(48 * time.Hour), Source: "tls"}


### PR DESCRIPTION
Busy FrankenPHP threads are sampled at each poll and their PHP memory usage is folded into (method, pattern) buckets, surfaced as sortable Avg Mem / Max Mem columns when FrankenPHP is detected. Closes #73.