### PR TITLE
feat: Display FrankenPHP workers utilization gauge in the header

### DIFF
--- a/docs/frankenphp-dashboard.md
+++ b/docs/frankenphp-dashboard.md
@@ -12,7 +12,8 @@ Some thread-level metrics require **FrankenPHP 1.12.2** or later. On older versi
 
 The top of the FrankenPHP tab displays:
 
-- **Thread bar**: A visual stacked bar showing the ratio of busy, idle, and inactive threads
+- **Workers bar**: A visual stacked bar showing the ratio of busy, idle, and inactive worker threads
+- **Thread bar**: A visual stacked bar showing the ratio of busy, idle, and inactive regular threads (only appears when regular, non-worker threads exist)
 - **Worker count**: Number of active workers
 - **Queue depth**: Requests waiting in the worker queue
 - **Crash counter**: Total worker crashes (highlighted when non-zero)

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -36,8 +36,15 @@ func renderDashboard(s *model.State, width int, version string, rpsHistory, cpuH
 	}
 
 	var threadBusy, threadIdle, threadTotal int
+	var workerBusy, workerIdle, workerTotal int
 	for _, t := range snap.Threads.ThreadDebugStates {
 		if workerScript(t.Name) != "" {
+			workerTotal++
+			if t.IsBusy {
+				workerBusy++
+			} else if t.IsWaiting {
+				workerIdle++
+			}
 			continue
 		}
 		threadTotal++
@@ -137,17 +144,33 @@ func renderDashboard(s *model.State, width int, version string, rpsHistory, cpuH
 	lines = append(lines, titleLine, line1, line2)
 
 	if hasFrankenPHP {
-		threadInactive := threadTotal - threadBusy - threadIdle
-		legend := fmt.Sprintf(" %s %s %s",
-			busyStyle.Render(fmt.Sprintf("%d busy", threadBusy)),
-			idleStyle.Render(fmt.Sprintf("%d idle", threadIdle)),
-			greyStyle.Render(fmt.Sprintf("%d inactive", threadInactive)),
-		)
-		legendW := lipgloss.Width(legend)
-		threadLabel := fmt.Sprintf(" Threads %d/%d ", threadBusy, threadTotal)
-		barMaxW := width - len(threadLabel) - legendW - 4
-		threadBar := renderThreadBar(threadBusy, threadIdle, threadTotal, barMaxW)
-		lines = append(lines, threadLabel+threadBar+legend)
+		if workerTotal > 0 {
+			workerInactive := workerTotal - workerBusy - workerIdle
+			legend := fmt.Sprintf(" %s %s %s",
+				busyStyle.Render(fmt.Sprintf("%d busy", workerBusy)),
+				idleStyle.Render(fmt.Sprintf("%d idle", workerIdle)),
+				greyStyle.Render(fmt.Sprintf("%d inactive", workerInactive)),
+			)
+			legendW := lipgloss.Width(legend)
+			workerLabel := fmt.Sprintf(" Workers %d/%d ", workerBusy, workerTotal)
+			barMaxW := width - len(workerLabel) - legendW - 4
+			workerBar := renderThreadBar(workerBusy, workerIdle, workerTotal, barMaxW)
+			lines = append(lines, workerLabel+workerBar+legend)
+		}
+
+		if threadTotal > 0 {
+			threadInactive := threadTotal - threadBusy - threadIdle
+			legend := fmt.Sprintf(" %s %s %s",
+				busyStyle.Render(fmt.Sprintf("%d busy", threadBusy)),
+				idleStyle.Render(fmt.Sprintf("%d idle", threadIdle)),
+				greyStyle.Render(fmt.Sprintf("%d inactive", threadInactive)),
+			)
+			legendW := lipgloss.Width(legend)
+			threadLabel := fmt.Sprintf(" Threads %d/%d ", threadBusy, threadTotal)
+			barMaxW := width - len(threadLabel) - legendW - 4
+			threadBar := renderThreadBar(threadBusy, threadIdle, threadTotal, barMaxW)
+			lines = append(lines, threadLabel+threadBar+legend)
+		}
 	}
 
 	if !snap.Metrics.HasHTTPMetrics && len(snap.Threads.ThreadDebugStates) == 0 {

--- a/internal/ui/dashboard_test.go
+++ b/internal/ui/dashboard_test.go
@@ -226,6 +226,53 @@ func TestFormatReloadAge(t *testing.T) {
 	assert.Equal(t, "3d 2h", formatReloadAge(74*time.Hour))
 }
 
+func TestRenderDashboard_FrankenPHPGauges(t *testing.T) {
+	// 1. Only workers
+	s1 := &model.State{
+		Current: &fetcher.Snapshot{
+			Threads: fetcher.ThreadsResponse{
+				ThreadDebugStates: []fetcher.ThreadDebugState{
+					{Name: "Worker PHP Thread - /app/worker.php", IsBusy: true},
+					{Name: "Worker PHP Thread - /app/worker.php", IsWaiting: true},
+				},
+			},
+		},
+	}
+	out1 := stripANSI(renderDashboard(s1, 120, "v0.1", nil, nil, false, false, true))
+	assert.Contains(t, out1, "Workers 1/2")
+	assert.NotContains(t, out1, "Threads")
+
+	// 2. Only normal threads
+	s2 := &model.State{
+		Current: &fetcher.Snapshot{
+			Threads: fetcher.ThreadsResponse{
+				ThreadDebugStates: []fetcher.ThreadDebugState{
+					{Name: "Regular PHP Thread", IsBusy: true},
+					{Name: "Regular PHP Thread", IsWaiting: true},
+				},
+			},
+		},
+	}
+	out2 := stripANSI(renderDashboard(s2, 120, "v0.1", nil, nil, false, false, true))
+	assert.Contains(t, out2, "Threads 1/2")
+	assert.NotContains(t, out2, "Workers")
+
+	// 3. Both workers and normal threads
+	s3 := &model.State{
+		Current: &fetcher.Snapshot{
+			Threads: fetcher.ThreadsResponse{
+				ThreadDebugStates: []fetcher.ThreadDebugState{
+					{Name: "Worker PHP Thread - /app/worker.php", IsBusy: true},
+					{Name: "Regular PHP Thread", IsWaiting: true},
+				},
+			},
+		},
+	}
+	out3 := stripANSI(renderDashboard(s3, 120, "v0.1", nil, nil, false, false, true))
+	assert.Contains(t, out3, "Workers 1/1")
+	assert.Contains(t, out3, "Threads 0/1")
+}
+
 func stripANSI(s string) string {
 	var out []rune
 	inEsc := false

--- a/local/frankenphp/Caddyfile
+++ b/local/frankenphp/Caddyfile
@@ -10,3 +10,11 @@
 	rewrite * /index.php
 	php
 }
+
+:8081 {
+	root * /app/public
+	rewrite * /worker.php
+	php {
+		worker /app/public/worker.php 4
+	}
+}

--- a/local/frankenphp/Makefile
+++ b/local/frankenphp/Makefile
@@ -6,8 +6,9 @@ up: ## Start docker compose via build & up in the local folder
 	@command -v docker >/dev/null 2>&1 || { echo >&2 "Docker is not installed. Please install it."; exit 1; }
 	docker compose build && docker compose up -d
 	@echo ""
-	@echo "  FrankenPHP  : http://localhost:8080"
-	@echo "  Caddy admin : http://localhost:2019"
+	@echo "  FrankenPHP (Normal)  : http://localhost:8080"
+	@echo "  FrankenPHP (Workers) : http://localhost:8081"
+	@echo "  Caddy admin          : http://localhost:2019"
 
 down: ## Clean docker compose in the local folder
 	@command -v docker >/dev/null 2>&1 || { echo >&2 "Docker is not installed. Please install it."; exit 1; }

--- a/local/frankenphp/compose.yaml
+++ b/local/frankenphp/compose.yaml
@@ -4,6 +4,7 @@ services:
     container_name: ember-frankenphp-local
     ports:
       - "8080:8080"
+      - "8081:8081"
       - "2019:2019"
     volumes:
       - ./public:/app/public

--- a/local/frankenphp/load.sh
+++ b/local/frankenphp/load.sh
@@ -43,10 +43,12 @@ gen_dynamic_path() {
 }
 
 pick_url() {
+  local port=$((RANDOM % 2 == 0 ? 8080 : 8081))
+  local b_url="http://localhost:$port"
   if (( RANDOM % 10 < 4 )); then
-    printf '%s%s\n' "$base_url" "${static_paths[RANDOM % ${#static_paths[@]}]}"
+    printf '%s%s\n' "$b_url" "${static_paths[RANDOM % ${#static_paths[@]}]}"
   else
-    printf '%s%s\n' "$base_url" "$(gen_dynamic_path)"
+    printf '%s%s\n' "$b_url" "$(gen_dynamic_path)"
   fi
 }
 
@@ -66,7 +68,7 @@ cleanup() {
 }
 trap cleanup INT TERM EXIT
 
-echo "Starting $WORKERS workers against $base_url"
+echo "Starting $WORKERS workers against http://localhost:8080 (Normal) and http://localhost:8081 (Workers)"
 for ((i=0; i<WORKERS; i++)); do
   worker &
   pids+=("$!")

--- a/local/frankenphp/public/worker.php
+++ b/local/frankenphp/public/worker.php
@@ -1,0 +1,28 @@
+<?php
+
+$maxRequests = 1000;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
+    $keepRunning = \frankenphp_handle_request(function () {
+        $ms = \random_int(10, 350);
+        \usleep($ms * 1000);
+
+        // Vary status codes by path so load.sh produces 200/404/500 like the caddy stack.
+        $path = \parse_url($_SERVER['REQUEST_URI'] ?? '/', \PHP_URL_PATH);
+        match ($path) {
+            '/notfound' => \http_response_code(404),
+            '/error' => \http_response_code(500),
+            default => null,
+        };
+
+        \header('Content-Type: application/json');
+        echo \json_encode([
+            'ms' => $ms,
+            'uniqid' => \uniqid(),
+            'worker' => true,
+        ]);
+    });
+
+    if (!$keepRunning) {
+        break;
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces a dynamic **Workers utilization gauge** in the dashboard header when running FrankenPHP in worker mode, addressing a limitation where the active load on workers wasn't visible "at a glance" without switching to the FrankenPHP tab.

Closes #76

### Why this is needed

When running FrankenPHP with worker mode enabled, all (or most) of the traffic is handled by the worker threads. However, the existing `Threads` gauge in the header explicitly filters out worker threads, meaning:
1. The header `Threads` gauge remains static (usually displaying `0 busy / 0 idle`), which isn't useful for monitoring.
2. Users lose the ability to see if their workers are saturated without manually switching tabs.

### What this PR does

1. **Stats Separation:**
   - Isolated worker thread statistics (`workerBusy`, `workerIdle`, `workerTotal`) from regular thread statistics within the `renderDashboard` function.
   - Identified worker threads using the existing `workerScript` helper.

2. **Dynamic Gauges Rendering:**
   - **`Workers` Gauge:** Rendered automatically if worker threads are detected (`workerTotal > 0`).
   - **`Threads` Gauge:** Rendered only if regular threads are present (`threadTotal > 0`).
   - If both are present, they stack beautifully on two lines. If only one type of thread is present, it displays a single gauge, keeping the header compact and fully backward-compatible.

3. **Verification & Testing:**
   - Added robust unit test cases (`TestRenderDashboard_FrankenPHPGauges` in `internal/ui/dashboard_test.go`) covering all scenarios (worker-only, thread-only, hybrid).
   - Enhanced the local `local/frankenphp` test stack by configuring port `8081` as a real worker-mode endpoint (with `worker.php` using `frankenphp_handle_request`) and updating the load generator `load.sh` to balance traffic across ports `8080` (normal) and `8081` (workers). This allows developers to easily test both gauges locally.

<img width="1173" height="309" alt="Capture d’écran 2026-07-22 à 13 23 34" src="https://github.com/user-attachments/assets/5ff0c24a-3fb5-4c6f-ae20-afd6fb2989be" />
