### PR TITLE
Feat/k8s pod monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Caddy exposes rich metrics through its admin API and Prometheus endpoint, but re
 - Config Inspector tab: browse the live Caddy JSON config as a collapsible tree
 - Certificates tab: TLS certificate monitoring with expiry tracking, color-coded warnings, and likely auto-renewal indication
 - Upstreams tab: reverse proxy upstream health monitoring with per-upstream status, auto-detected when `reverse_proxy` is configured
-- Logs tab: live access and runtime log streaming in a single view, with a sidepanel tree (Runtime, Access, per-host children, [By Route](docs/logs.md#by-route-view) aggregation) and a free-text filter. Zero-config: Ember hot-registers two transient sinks in Caddy via the admin API (`__ember__` for access logs, `__ember_runtime__` for everything else) and receives logs over TCP with no Caddyfile changes
+- Logs tab: live access and runtime log streaming in a single view, with a sidepanel tree (Runtime, Access, per-host children, [By Route](docs/logs.md#by-route-view) aggregation) and a free-text filter. Zero-config: Ember hot-registers two transient sinks in Caddy via the admin API (`__ember__` for access logs, `__ember_runtime__` for everything else) and receives logs over TCP with no Caddyfile changes, or streams them directly from standard input (stdin)
 - Automatic Caddy restart detection
 
 **FrankenPHP Introspection**
@@ -49,7 +49,7 @@ Caddy exposes rich metrics through its admin API and Prometheus endpoint, but re
 - Zero-config setup: `ember init` checks Caddy, enables metrics, and warns about missing host matchers
 - Unix socket support for Caddy admin APIs configured with `admin unix//path`
 - TLS and mTLS support for secured Caddy admin APIs
-- Environment variable configuration (`EMBER_ADDR`, `EMBER_EXPOSE`, `EMBER_LOG_LISTEN`, ...) for container deployments
+- Environment variable configuration (`EMBER_ADDR`, `EMBER_EXPOSE`, `EMBER_LOG_LISTEN`, `EMBER_STDIN_LOGS`, ...) for container deployments
 - [Config file](docs/cli-reference.md#config-file) (`.ember.toml`): declare a fleet of named endpoints once instead of repeating `--addr`. The TUI connects to one (a saved `default` or an interactive picker); `--daemon`, `--json`, `status`, `wait`, and `init` fan out across all of them. `ember config use <name>` sets the TUI default
 - `NO_COLOR` env var support ([no-color.org](https://no-color.org/))
 - Lightweight: ~15 MB RSS, ~0.3 ms per poll cycle with 100 threads and 10 hosts ([benchmarks](internal/app/daemon_bench_test.go))

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -28,6 +28,7 @@ ember [flags]
 | `-f`, `--config`   | string | `.ember.toml` | Path to the Ember config file (TOML). Read only when neither `--addr` nor `EMBER_ADDR` is set. See [Config file](#config-file). |
 | `--metrics-auth`   | string | _(none)_ | Basic auth for the metrics endpoint (`user:password`). Requires `--expose`. See [Prometheus Export](prometheus-export.md). |
 | `--log-listen`     | string | _(auto)_ | Bind a TCP listener at this address (e.g. `:9210`) and ask Caddy to push its logs to it via two hot-registered sinks (access + runtime). Required when Caddy is on a remote host; auto-bound on a free loopback port otherwise. See [Logs](logs.md). |
+| `--stdin-logs`, `--from-stdin` | bool | `false` | Read Caddy logs directly from stdin instead of registering a net_writer via Caddy's Admin API. Ideal for Kubernetes / unidirectional environments. |
 | `--no-color`       | bool | `false` | Disable colors. Also enabled by the `NO_COLOR` env var (see [no-color.org](https://no-color.org/)). |
 | `--version`        | | | Print version and exit |
 
@@ -43,6 +44,9 @@ Some flags can be set via environment variables. Explicit flags always take prec
 | `EMBER_METRICS_PREFIX` | `--metrics-prefix` | `EMBER_METRICS_PREFIX=myapp` |
 | `EMBER_METRICS_AUTH` | `--metrics-auth` | `EMBER_METRICS_AUTH=admin:secret` |
 | `EMBER_LOG_LISTEN` | `--log-listen` | `EMBER_LOG_LISTEN=:9210` |
+| `EMBER_STDIN_LOGS` | `--stdin-logs` | `EMBER_STDIN_LOGS=true` |
+| `EMBER_FROM_STDIN` | `--from-stdin` | `EMBER_FROM_STDIN=true` |
+| `CADDY_API_URL` | `--addr` | `CADDY_API_URL=http://localhost:2019` |
 | `EMBER_CONFIG` | `--config` | `EMBER_CONFIG=/etc/ember/prod.toml` |
 
 This is especially useful in container deployments where flags are less convenient than environment variables. Using `EMBER_METRICS_AUTH` is recommended over the flag to avoid exposing credentials in `ps` output.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,8 +44,7 @@ Some flags can be set via environment variables. Explicit flags always take prec
 | `EMBER_METRICS_PREFIX` | `--metrics-prefix` | `EMBER_METRICS_PREFIX=myapp` |
 | `EMBER_METRICS_AUTH` | `--metrics-auth` | `EMBER_METRICS_AUTH=admin:secret` |
 | `EMBER_LOG_LISTEN` | `--log-listen` | `EMBER_LOG_LISTEN=:9210` |
-| `EMBER_STDIN_LOGS` | `--stdin-logs` | `EMBER_STDIN_LOGS=true` |
-| `EMBER_FROM_STDIN` | `--from-stdin` | `EMBER_FROM_STDIN=true` |
+| `EMBER_STDIN_LOGS` | `--stdin-logs`, `--from-stdin` | `EMBER_STDIN_LOGS=true` |
 | `CADDY_API_URL` | `--addr` | `CADDY_API_URL=http://localhost:2019` |
 | `EMBER_CONFIG` | `--config` | `EMBER_CONFIG=/etc/ember/prod.toml` |
 

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -74,7 +74,7 @@ This enables a completely unidirectional mode where:
 
 2. **Stream Pod logs and pipe them into Ember** on your local machine:
    ```bash
-   kubectl logs -f pod/my-caddy-pod-abcde -c caddy \| ember --stdin-logs --addr http://localhost:2019
+   kubectl logs -f pod/my-caddy-pod-abcde -c caddy | ember --stdin-logs --addr http://localhost:2019
    ```
 
    *(Note: The `-c caddy` flag specifies the container name if you are running Caddy alongside other containers in a sidecar pattern).*

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -44,6 +44,7 @@ ends the session exactly where it started.
 | Caddy over a Unix socket                     | `ember --addr unix//path/to/admin.sock`                 |
 | Caddy on a remote host                       | `ember --addr http://remote:2019 --log-listen :9210`    |
 | Caddy in Docker (macOS/Windows)              | `ember --log-listen host.docker.internal:9210`          |
+| Caddy in Kubernetes Pod (CLI)                | `kubectl logs -f <pod> \| ember --stdin-logs --addr http://localhost:2019` |
 
 When `--addr` points at a non-local host, Ember does **not** auto-bind a
 listener: a `127.0.0.1:<port>` address would not be reachable from the remote
@@ -55,6 +56,32 @@ When the hostname in `--log-listen` cannot be resolved locally (e.g.
 `host.docker.internal`), Ember binds on `0.0.0.0:<port>` instead and
 advertises the original address to Caddy. This lets a containerised Caddy
 reach the host without extra networking setup.
+
+## Reading from Stdin (Kubernetes CLI Monitoring)
+
+In environments like Kubernetes where egress is restricted, or when you want to monitor a remote Pod locally without changing Caddy's configuration, you can use the `--stdin-logs` (or `--from-stdin`) flag. 
+
+This enables a completely unidirectional mode where:
+1. Ember does **not** attempt to register any network sinks in Caddy.
+2. Ember reads JSON logs directly from its standard input (`stdin`).
+
+### Step-by-Step Guide
+
+1. **Port-forward Caddy's Admin API** to your local machine so Ember can fetch metrics and configurations:
+   ```bash
+   kubectl port-forward pod/my-caddy-pod-abcde 2019:2019
+   ```
+
+2. **Stream Pod logs and pipe them into Ember** on your local machine:
+   ```bash
+   kubectl logs -f pod/my-caddy-pod-abcde -c caddy \| ember --stdin-logs --addr http://localhost:2019
+   ```
+
+   *(Note: The `-c caddy` flag specifies the container name if you are running Caddy alongside other containers in a sidecar pattern).*
+
+### Why use this approach?
+- **No Side-Effects:** Since Ember reads from stdin, it does not alter Caddy's log writers, making it perfectly safe for read-only production environments.
+- **Full TUI Features:** You still get the full terminal UI experience including real-time access logs, runtime logs, and the **By Route** aggregated statistics.
 
 ## Hot-registered sinks
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -227,7 +227,6 @@ var envBindings = map[string]string{
 	"log-listen":     "EMBER_LOG_LISTEN",
 	"config":         "EMBER_CONFIG",
 	"stdin-logs":     "EMBER_STDIN_LOGS",
-	"from-stdin":     "EMBER_FROM_STDIN",
 }
 
 // bindEnv applies EMBER_* and other supported variables (e.g. CADDY_API_URL)
@@ -238,7 +237,15 @@ var envBindings = map[string]string{
 func bindEnv(cmd *cobra.Command) error {
 	for name, env := range envBindings {
 		f := cmd.Flag(name)
-		if f == nil || f.Changed {
+		if f == nil {
+			continue
+		}
+		if name == "stdin-logs" {
+			fromStdinFlag := cmd.Flag("from-stdin")
+			if f.Changed || (fromStdinFlag != nil && fromStdinFlag.Changed) {
+				continue
+			}
+		} else if f.Changed {
 			continue
 		}
 		var val string
@@ -301,6 +308,12 @@ func validate(cfg *config) error {
 	}
 	if cfg.stdinLogs && cfg.logListen != "" {
 		return fmt.Errorf("--stdin-logs / --from-stdin is incompatible with --log-listen")
+	}
+	if cfg.stdinLogs {
+		stat, err := os.Stdin.Stat()
+		if err == nil && (stat.Mode()&os.ModeCharDevice) != 0 {
+			return fmt.Errorf("stdin is a terminal; cannot stream logs from it (use a pipe or redirection)")
+		}
 	}
 	if cfg.interval < minInterval {
 		return fmt.Errorf("--interval must be at least %s", minInterval)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -42,6 +42,7 @@ type config struct {
 	configPath    string
 	configDefault string
 	addrsFromFile bool
+	stdinLogs     bool
 }
 
 func Run(args []string, version string) error {
@@ -173,6 +174,8 @@ Keybindings:
 	f.StringVar(&cfg.logFormat, "log-format", "text", "Log format for daemon/json modes (text or json)")
 	f.StringVar(&cfg.metricsAuth, "metrics-auth", "", "Basic auth for metrics endpoint (user:password)")
 	f.StringVar(&cfg.logListen, "log-listen", "", "Receive logs from Caddy via TCP, e.g. ':9210' or '127.0.0.1:9210'. Required when Caddy is on a remote host; auto-bound on a local loopback port otherwise.")
+	f.BoolVar(&cfg.stdinLogs, "stdin-logs", false, "Read Caddy logs directly from stdin instead of registering a net_writer")
+	f.BoolVar(&cfg.stdinLogs, "from-stdin", false, "Read Caddy logs directly from stdin instead of registering a net_writer (alias for --stdin-logs)")
 
 	cmd.AddCommand(newStatusCmd(&cfg))
 	cmd.AddCommand(newWaitCmd(&cfg))
@@ -223,19 +226,31 @@ var envBindings = map[string]string{
 	"metrics-auth":   "EMBER_METRICS_AUTH",
 	"log-listen":     "EMBER_LOG_LISTEN",
 	"config":         "EMBER_CONFIG",
+	"stdin-logs":     "EMBER_STDIN_LOGS",
+	"from-stdin":     "EMBER_FROM_STDIN",
 }
 
-// bindEnv applies EMBER_* variables to flags the user did not set on the
-// command line. Value.Set does not flip Changed, so we set it explicitly once a
-// value lands: env-provided values must win over the config file, which is
-// skipped precisely when the addr (or per-key) flag is Changed.
+// bindEnv applies EMBER_* and other supported variables (e.g. CADDY_API_URL)
+// to flags the user did not set on the command line. Value.Set does not flip
+// Changed, so we set it explicitly once a value lands: env-provided values
+// must win over the config file, which is skipped precisely when the addr
+// (or per-key) flag is Changed.
 func bindEnv(cmd *cobra.Command) error {
 	for name, env := range envBindings {
 		f := cmd.Flag(name)
 		if f == nil || f.Changed {
 			continue
 		}
-		val, ok := os.LookupEnv(env)
+		var val string
+		var ok bool
+		if name == "addr" {
+			val, ok = os.LookupEnv("CADDY_API_URL")
+			if !ok {
+				val, ok = os.LookupEnv("EMBER_ADDR")
+			}
+		} else {
+			val, ok = os.LookupEnv(env)
+		}
 		if !ok {
 			continue
 		}
@@ -246,7 +261,11 @@ func bindEnv(cmd *cobra.Command) error {
 					continue
 				}
 				if err := f.Value.Set(v); err != nil {
-					return fmt.Errorf("%s=%q: %w", env, v, err)
+					envName := "EMBER_ADDR"
+					if _, okCaddy := os.LookupEnv("CADDY_API_URL"); okCaddy {
+						envName = "CADDY_API_URL"
+					}
+					return fmt.Errorf("%s=%q: %w", envName, v, err)
 				}
 				f.Changed = true
 			}
@@ -273,6 +292,15 @@ func validate(cfg *config) error {
 	}
 	if cfg.once && cfg.daemon {
 		return fmt.Errorf("--once is incompatible with --daemon")
+	}
+	if cfg.stdinLogs && cfg.daemon {
+		return fmt.Errorf("--stdin-logs / --from-stdin is incompatible with --daemon")
+	}
+	if cfg.stdinLogs && cfg.jsonMode {
+		return fmt.Errorf("--stdin-logs / --from-stdin is incompatible with --json")
+	}
+	if cfg.stdinLogs && cfg.logListen != "" {
+		return fmt.Errorf("--stdin-logs / --from-stdin is incompatible with --log-listen")
 	}
 	if cfg.interval < minInterval {
 		return fmt.Errorf("--interval must be at least %s", minInterval)

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -206,6 +206,27 @@ func TestValidate_OnceWithJSONOK(t *testing.T) {
 	assert.NoError(t, validate(cfg))
 }
 
+func TestValidate_StdinLogsWithDaemon(t *testing.T) {
+	cfg := &config{stdinLogs: true, daemon: true, expose: ":9191", interval: 1 * time.Second, addrsRaw: []string{"http://localhost:2019"}}
+	err := validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--stdin-logs / --from-stdin is incompatible with --daemon")
+}
+
+func TestValidate_StdinLogsWithJSON(t *testing.T) {
+	cfg := &config{stdinLogs: true, jsonMode: true, interval: 1 * time.Second, addrsRaw: []string{"http://localhost:2019"}}
+	err := validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--stdin-logs / --from-stdin is incompatible with --json")
+}
+
+func TestValidate_StdinLogsWithLogListen(t *testing.T) {
+	cfg := &config{stdinLogs: true, logListen: ":9210", interval: 1 * time.Second, addrsRaw: []string{"http://localhost:2019"}}
+	err := validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--stdin-logs / --from-stdin is incompatible with --log-listen")
+}
+
 func TestRun_OnceWithoutJSON(t *testing.T) {
 	err := Run([]string{"--once"}, "0.0.0")
 	require.Error(t, err)
@@ -538,6 +559,43 @@ func TestBindEnv_AddrFromEnv(t *testing.T) {
 	require.NoError(t, bindEnv(cmd))
 
 	assert.Equal(t, "[http://remote:2019]", cmd.Flag("addr").Value.String())
+}
+
+func TestBindEnv_CaddyApiUrlFromEnv(t *testing.T) {
+	t.Setenv("CADDY_API_URL", "http://caddyremote:2019")
+
+	cmd := newRootCmd("0.0.0")
+	require.NoError(t, bindEnv(cmd))
+
+	assert.Equal(t, "[http://caddyremote:2019]", cmd.Flag("addr").Value.String())
+}
+
+func TestBindEnv_CaddyApiUrlTakesPrecedenceOverEmberAddr(t *testing.T) {
+	t.Setenv("CADDY_API_URL", "http://caddyremote:2019")
+	t.Setenv("EMBER_ADDR", "http://emberremote:2019")
+
+	cmd := newRootCmd("0.0.0")
+	require.NoError(t, bindEnv(cmd))
+
+	assert.Equal(t, "[http://caddyremote:2019]", cmd.Flag("addr").Value.String())
+}
+
+func TestBindEnv_StdinLogsFromEnv(t *testing.T) {
+	t.Setenv("EMBER_STDIN_LOGS", "true")
+
+	cmd := newRootCmd("0.0.0")
+	require.NoError(t, bindEnv(cmd))
+
+	assert.Equal(t, "true", cmd.Flag("stdin-logs").Value.String())
+}
+
+func TestBindEnv_FromStdinFromEnv(t *testing.T) {
+	t.Setenv("EMBER_FROM_STDIN", "true")
+
+	cmd := newRootCmd("0.0.0")
+	require.NoError(t, bindEnv(cmd))
+
+	assert.Equal(t, "true", cmd.Flag("from-stdin").Value.String())
 }
 
 func TestBindEnv_InvalidIntervalIsError(t *testing.T) {

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -589,13 +590,39 @@ func TestBindEnv_StdinLogsFromEnv(t *testing.T) {
 	assert.Equal(t, "true", cmd.Flag("stdin-logs").Value.String())
 }
 
-func TestBindEnv_FromStdinFromEnv(t *testing.T) {
-	t.Setenv("EMBER_FROM_STDIN", "true")
+func TestBindEnv_Precedence_StdinLogs(t *testing.T) {
+	t.Setenv("EMBER_STDIN_LOGS", "true")
 
 	cmd := newRootCmd("0.0.0")
+	require.NoError(t, cmd.Flags().Set("stdin-logs", "false"))
 	require.NoError(t, bindEnv(cmd))
 
-	assert.Equal(t, "true", cmd.Flag("from-stdin").Value.String())
+	assert.Equal(t, "false", cmd.Flag("stdin-logs").Value.String())
+}
+
+func TestBindEnv_Precedence_FromStdin(t *testing.T) {
+	t.Setenv("EMBER_STDIN_LOGS", "true")
+
+	cmd := newRootCmd("0.0.0")
+	require.NoError(t, cmd.Flags().Set("from-stdin", "false"))
+	require.NoError(t, bindEnv(cmd))
+
+	assert.Equal(t, "false", cmd.Flag("stdin-logs").Value.String())
+}
+
+func TestValidate_StdinIsTerminal(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+	defer f.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = f
+	defer func() { os.Stdin = oldStdin }()
+
+	cfg := &config{stdinLogs: true, interval: 1 * time.Second, addrsRaw: []string{"http://localhost:2019"}}
+	err = validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stdin is a terminal; cannot stream logs from it")
 }
 
 func TestBindEnv_InvalidIntervalIsError(t *testing.T) {

--- a/internal/app/stdin_logs_test.go
+++ b/internal/app/stdin_logs_test.go
@@ -1,0 +1,112 @@
+package app
+
+import (
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alexandre-daubois/ember/internal/model"
+	"github.com/alexandre-daubois/ember/internal/ui"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsJSONLogLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		expected bool
+	}{
+		{
+			name:     "valid caddy access log",
+			line:     `{"level":"info","ts":1710000000.123,"logger":"http.log.access","msg":"handled request"}`,
+			expected: true,
+		},
+		{
+			name:     "valid caddy runtime log",
+			line:     `{"level":"warn","ts":1710000000.123,"logger":"tls","msg":"certificate expiring soon"}`,
+			expected: true,
+		},
+		{
+			name:     "non-json line",
+			line:     `hello world`,
+			expected: false,
+		},
+		{
+			name:     "json but not log structure",
+			line:     `{"hello":"world"}`,
+			expected: false,
+		},
+		{
+			name:     "empty object",
+			line:     `{}`,
+			expected: false,
+		},
+		{
+			name:     "valid general log",
+			line:     `{"msg":"started service"}`,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isJSONLogLine(tt.line))
+		})
+	}
+}
+
+func TestStartStdinListener(t *testing.T) {
+	// Keep a backup of os.Stdin and restore it afterwards
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdin = r
+
+	uiCfg := &ui.Config{}
+
+	// Start stdin listener
+	cleanup, ok := startStdinListener(nil, uiCfg)
+	require.True(t, ok)
+	defer cleanup()
+
+	// Write some valid logs and some non-log lines to the pipe
+	logs := []string{
+		// Valid access log
+		`{"level":"info","ts":1710000000.123,"logger":"http.log.access.log0","msg":"handled request","request":{"host":"localhost","method":"GET","uri":"/","remote_ip":"127.0.0.1"},"status":200}`,
+		// Non-JSON noise (should be ignored)
+		`Some Kubernetes controller stdout line`,
+		// Prefixed valid runtime log
+		`2026-07-23T14:31:00Z stdout F {"level":"warn","ts":1710000000.123,"logger":"tls","msg":"certificate warning"}`,
+	}
+
+	for _, log := range logs {
+		_, err := io.WriteString(w, log+"\n")
+		require.NoError(t, err)
+	}
+
+	// Close write end of pipe so scanner finishes
+	_ = w.Close()
+
+	// Give the reader goroutine a brief moment to process the logs
+	assert.Eventually(t, func() bool {
+		return uiCfg.LogBuffer != nil && uiCfg.RuntimeLogBuffer != nil &&
+			uiCfg.LogBuffer.Len() == 1 && uiCfg.RuntimeLogBuffer.Len() == 1
+	}, 1*time.Second, 10*time.Millisecond)
+
+	// Verify access log content
+	accessLogs := uiCfg.LogBuffer.Snapshot(model.LogFilter{}, 0)
+	require.Len(t, accessLogs, 1)
+	assert.Equal(t, "localhost", accessLogs[0].Host)
+	assert.Equal(t, "GET", accessLogs[0].Method)
+	assert.Equal(t, 200, accessLogs[0].Status)
+
+	// Verify runtime log content
+	runtimeLogs := uiCfg.RuntimeLogBuffer.Snapshot(model.LogFilter{}, 0)
+	require.Len(t, runtimeLogs, 1)
+	assert.Equal(t, "certificate warning", runtimeLogs[0].Message)
+	assert.Equal(t, "warn", runtimeLogs[0].Level)
+}

--- a/internal/app/tui.go
+++ b/internal/app/tui.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -112,6 +114,12 @@ func runTUI(f fetcher.Fetcher, cfg *config, interval time.Duration, hasFrankenPH
 // access logging on every server that did not already have a logs block. The
 // returned cleanup function reverses both changes.
 func setupLogSource(cfg *config, f fetcher.Fetcher, uiCfg *ui.Config) func() {
+	if cfg.stdinLogs {
+		if cleanup, ok := startStdinListener(f, uiCfg); ok {
+			return cleanup
+		}
+		return func() {}
+	}
 	addr := cfg.logListen
 	if addr == "" {
 		if !isLocalAdminAddr(cfg.addrs[0].url) {
@@ -123,6 +131,78 @@ func setupLogSource(cfg *config, f fetcher.Fetcher, uiCfg *ui.Config) func() {
 		return cleanup
 	}
 	return func() {}
+}
+
+func startStdinListener(f fetcher.Fetcher, uiCfg *ui.Config) (func(), bool) {
+	accessBuf := model.NewLogBuffer(0)
+	runtimeBuf := model.NewLogBuffer(0)
+	routeAgg := model.NewRouteAggregator()
+	uiCfg.LogBuffer = accessBuf
+	uiCfg.RuntimeLogBuffer = runtimeBuf
+	uiCfg.RouteAggregator = routeAgg
+	uiCfg.LogSource = "stdin"
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			if !scanner.Scan() {
+				return
+			}
+
+			line := scanner.Text()
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+
+			start := strings.Index(trimmed, "{")
+			end := strings.LastIndex(trimmed, "}")
+			if start != -1 && end != -1 && end > start {
+				trimmed = trimmed[start : end+1]
+			}
+
+			if !isJSONLogLine(trimmed) {
+				continue
+			}
+
+			e := fetcher.ParseLogLine(trimmed)
+			if e.IsAccessLog() {
+				accessBuf.Append(e)
+				routeAgg.Track(e)
+			} else {
+				runtimeBuf.Append(e)
+			}
+		}
+	}()
+
+	return func() {
+		cancel()
+	}, true
+}
+
+func isJSONLogLine(line string) bool {
+	if !strings.HasPrefix(line, "{") || !strings.HasSuffix(line, "}") {
+		return false
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(line), &m); err != nil {
+		return false
+	}
+	_, hasLevel := m["level"]
+	_, hasTS := m["ts"]
+	_, hasMsg := m["msg"]
+	_, hasLogger := m["logger"]
+	return hasLevel || hasTS || hasMsg || hasLogger
 }
 
 var sinkWatchdogInterval = 30 * time.Second


### PR DESCRIPTION
### Description

This PR adds support for a completely **unidirectional and non-intrusive monitoring mode** by allowing Ember to read Caddy JSON logs directly from `stdin` instead of registering network TCP log sinks in Caddy via the Admin API. 

It also adds support for the `CADDY_API_URL` environment variable to configure the Caddy Admin API endpoint, taking precedence over `EMBER_ADDR`.

### Why this is needed

In many modern containerized environments, especially **Kubernetes**, there are two main challenges for monitoring:
1. **Restricted Egress / Unidirectional Network Paths**: Firewalls or cluster rules might prevent Caddy (inside a pod/container) from opening a TCP connection to stream logs outward to a locally running Ember instance on a developer's machine.
2. **Read-Only / Side-Effect Free Local Inspection**: Developers often want to use Ember's rich TUI to monitor a running remote/production pod *without* altering Caddy's configuration or adding log writers.

By allowing Caddy logs to be streamed directly via `stdin` (e.g., piped from `kubectl logs -f`), Ember can now provide its full real-time log viewing (Runtime, Access, By Route stats) completely passively.

---

### What this PR does

1. **Stdin Log Source Support**:
   - Added `--stdin-logs` / `--from-stdin` boolean flags (and matching environment variables `EMBER_STDIN_LOGS` / `EMBER_FROM_STDIN`).
   - Implemented `startStdinListener` in `internal/app/tui.go` which spawns a background goroutine to read, sanitize, parse, and route JSON log entries directly from standard input.
   - Restricts flags with strict CLI validation checks (incompatible with `--daemon`, `--json`, and `--log-listen`).

2. **Caddy API URL Binding Precedence**:
   - Binds `CADDY_API_URL` environment variable to configure the Caddy address, aligning with standard Caddy tooling configurations and prioritizing it over `EMBER_ADDR`.

3. **Verification & Testing**:
   - Created a comprehensive test suite in `internal/app/stdin_logs_test.go` covering JSON log line detection and stdin processing correctness.
   - Updated `internal/app/run_test.go` with strict flag incompatibility validation test cases and environment binding tests.

4. **Documentation**:
   - Updated `docs/cli-reference.md` to reference the new CLI flags and environment variables.
   - Added a detailed, step-by-step developer guide in `docs/logs.md` explaining how to combine `kubectl port-forward` and `kubectl logs | ember --stdin-logs` to monitor live pods.

---

### How to Test

1. **Automated Unit Tests**:
   Ensure all tests in the package pass successfully:
   ```bash
   go test ./internal/app/...
   ```

2. **Manual CLI Verification**:
   Verify flag validation checks:
   ```bash
   # Should fail with clear incompatibility errors:
   ember --stdin-logs --daemon
   ember --stdin-logs --json
   ember --stdin-logs --log-listen :9210
   ```
